### PR TITLE
create and implement event manager functions

### DIFF
--- a/cdh/include/eventManager.h
+++ b/cdh/include/eventManager.h
@@ -1,0 +1,42 @@
+/*
+ * eventManager.h
+ *
+ * May 31, 2022
+ * kiransuren
+ *
+ */
+
+
+#ifndef EVENTMANAGER_H
+#define EVENTMANAGER_H
+
+#include <stdint.h>
+#include "os_portmacro.h"
+
+#define NUM_OF_QUEUES 3
+#define QUEUE_LENGTH 10
+#define QUEUE_ITEM_SIZE sizeof(uint16_t)
+#define QUEUE_WAIT_PERIOD 10/portTICK_PERIOD_MS     //TODO: May need to change this wait period depending on testing
+#define MASTER_EVENT_MUTEX_WAIT 10/portTICK_PERIOD_MS        //TODO: Not a good idea to indefinitely wait to push to a queue, figure out another solution
+
+typedef enum{
+    SUPERVISOR_QUEUE_ID,
+    COMMS_QUEUE_ID,
+    ADCS_QUEUE_ID
+} event_queue_id;
+
+// TODO: refactor location of event id enum, maybe new events header file?
+typedef enum{
+    NULL_EVENT_ID,
+    TEST_EVENT1_ID,
+    TEST_EVENT2_ID,
+    TEST_EVENT3_ID,
+    TEST_EVENT4_ID
+} event_id;
+
+
+void initializeEventQueues();
+void addEventQueue(event_queue_id eventQueueID, event_id eventID);
+event_id receiveEventQueue(event_queue_id eventQueueID);
+
+#endif

--- a/cdh/include/supervisor.h
+++ b/cdh/include/supervisor.h
@@ -13,7 +13,7 @@
 #define SUPERVISOR_STACK_SIZE   1024
 #define SUPERVISOR_NAME         "supervisor"
 #define SUPERVISOR_PRIORITY     1
-#define SUPERVISOR_DELAY_TICKS  100
+#define SUPERVISOR_DELAY_TICKS  1000/portTICK_PERIOD_MS
 
 void vSupervisorTask(void * pvParameters);
 

--- a/cdh/source/eventManager.c
+++ b/cdh/source/eventManager.c
@@ -1,0 +1,68 @@
+/*
+ * eventManager.c
+ *
+ * May 31, 2022
+ * kiransuren
+ *
+ */
+
+#include "eventManager.h"
+
+#include "FreeRTOS.h"
+#include "os_queue.h"
+#include "os_portmacro.h"
+#include "os_task.h"
+#include "os_semphr.h"
+
+#include "sys_common.h"
+#include <stdint.h>
+
+static QueueHandle_t masterEventQueueList[NUM_OF_QUEUES];           // list of FreeRTOS queues that represent each tasks' event queue
+static SemaphoreHandle_t masterEventQueueListMutex;
+
+/*
+ * initializeEventQueues
+ *
+ * initializes the masterQueueList by creating queue handles for every task
+ */
+void initializeEventQueues(){
+    for(int i=0; i<NUM_OF_QUEUES; i++){
+        masterEventQueueList[i] = xQueueCreate(QUEUE_LENGTH, QUEUE_ITEM_SIZE);
+    }
+    masterEventQueueListMutex = xSemaphoreCreateMutex();
+}
+
+/*
+ * addEventQueue
+ * - adds a event to the specified event queue
+ *
+ * @param eventQueueID - the queue to be sent to
+ * @param eventID - the event enum to send to the queue
+ */
+void addEventQueue(event_queue_id eventQueueID, event_id eventID){
+    if(xSemaphoreTake(masterEventQueueListMutex, MASTER_EVENT_MUTEX_WAIT)){     //TODO: This mau not be an ideal piece of code, talk to Kiran about more details
+        QueueHandle_t queueHandle = masterEventQueueList[eventQueueID];
+        xQueueSend(queueHandle, (void *) &eventID, QUEUE_WAIT_PERIOD);
+        xSemaphoreGive(masterEventQueueListMutex);
+    }
+}
+
+/*
+ * receiveEventQueue
+ * - receives (pops) event from queue
+ *
+ * @param eventQueueID - the queue to receive from
+ * @return the event enum popped from the queue
+ */
+event_id receiveEventQueue(event_queue_id eventQueueID){
+    QueueHandle_t queueHandle = masterEventQueueList[eventQueueID];
+    event_id eventID;
+    if(xQueueReceive(queueHandle, (void *) &eventID, QUEUE_WAIT_PERIOD)){   // TODO: Do we need a mutex for reading?
+        return eventID;
+    }
+    return NULL_EVENT_ID;
+}
+
+
+
+

--- a/cdh/source/supervisor.c
+++ b/cdh/source/supervisor.c
@@ -14,12 +14,23 @@
 
 #include "sys_common.h"
 #include "gio.h"
+#include "eventManager.h"
 
 void vSupervisorTask(void * pvParameters){
+    initializeEventQueues();        // MUST be completed before any other tasks are initialized
 
     while(1){
-        gioToggleBit(gioPORTB, 1);
-        vTaskDelay(SUPERVISOR_DELAY_TICKS);
+        event_id eventID = receiveEventQueue(SUPERVISOR_QUEUE_ID);
+
+        switch(eventID){
+            case TEST_EVENT1_ID:
+                gioToggleBit(gioPORTB, 1);
+                break;
+            default:
+                gioToggleBit(gioPORTB, 0);
+                vTaskDelay(SUPERVISOR_DELAY_TICKS);
+                addEventQueue(SUPERVISOR_QUEUE_ID, TEST_EVENT1_ID);
+        }
     }
 }
 

--- a/hal/include/FreeRTOSConfig.h
+++ b/hal/include/FreeRTOSConfig.h
@@ -124,7 +124,7 @@
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 
 /* Mutexes */
-#define configUSE_MUTEXES               0
+#define configUSE_MUTEXES               1
 #define configUSE_RECURSIVE_MUTEXES     0
 
 /* Semaphores */


### PR DESCRIPTION
- use event manager functions in supervisor (spoofed LED events)
- enables mutexes in FreeRTOS config
- add some comments and general code clean up

These functions will allow tasks send commands or "events" to each other. For example, after receiving raw data from the transceiver IC, the comms task will decode the information and send a pointing command to the ADCS event queue (from which ADCS will read the queue and act upon the command ASAP)