### PR TITLE
Updated SCI and I2C protection mutexes to statically allocate

### DIFF
--- a/drivers/source/obc_i2c_io.c
+++ b/drivers/source/obc_i2c_io.c
@@ -9,10 +9,11 @@
 #include <sys_common.h>
 
 static SemaphoreHandle_t i2cMutex = NULL;
+static StaticSemaphore_t i2cMutexBuffer;
 
 void initI2CMutex(void) {
     if (i2cMutex == NULL) {
-        i2cMutex = xSemaphoreCreateMutex();
+        i2cMutex = xSemaphoreCreateMutexStatic(&i2cMutexBuffer);
     }
 }
 

--- a/drivers/source/obc_i2c_io.c
+++ b/drivers/source/obc_i2c_io.c
@@ -15,6 +15,8 @@ void initI2CMutex(void) {
     if (i2cMutex == NULL) {
         i2cMutex = xSemaphoreCreateMutexStatic(&i2cMutexBuffer);
     }
+
+    configASSERT(i2cMutex);
 }
 
 uint8_t i2cSendTo(uint8_t sAddr, uint16_t size, void *buf) {

--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -27,6 +27,9 @@ void initSciMutex(void) {
     if (sciLinMutex == NULL) {
         sciLinMutex = xSemaphoreCreateMutexStatic(&sciLinMutexBuffer);
     }
+
+    configASSERT(sciMutex);
+    configASSERT(sciLinMutex);
 }
 
 uint8_t printTextSci(sciBASE_t *sci, unsigned char *text, uint32_t length) {

--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -7,7 +7,9 @@
 #include <sci.h>
 
 static SemaphoreHandle_t sciMutex = NULL;
+static StaticSemaphore_t sciMutexBuffer;
 static SemaphoreHandle_t sciLinMutex = NULL;
+static StaticSemaphore_t sciLinMutexBuffer;
 
 /**
  * @brief Iterate through an array of bytes and transmit them via SCI or SCI2.
@@ -20,10 +22,10 @@ static void sciSendBytes(sciBASE_t *sci, unsigned char *bytes, uint32_t length);
 
 void initSciMutex(void) {
     if (sciMutex == NULL) {
-        sciMutex = xSemaphoreCreateMutex();
+        sciMutex = xSemaphoreCreateMutexStatic(&sciMutexBuffer);
     }
     if (sciLinMutex == NULL) {
-        sciLinMutex = xSemaphoreCreateMutex();
+        sciLinMutex = xSemaphoreCreateMutexStatic(&sciLinMutexBuffer);
     }
 }
 


### PR DESCRIPTION
# Purpose
-The protection mutexes for SCI, SCI2, and I2C had to be updated to statically allocate. They were initially dynamically allocated.

# New Changes
- Used xSemaphoreCreateMutexStatic to statically allocate the protection mutexes for SCI, SCI2, and I2C. 
- xSemaphoreCreateMutexStatic requires a pointer to a variable of type StaticSemaphore_t which is used to hold the mutex type semaphore's state. 

# Reference
- https://www.freertos.org/xSemaphoreCreateMutexStatic.html
