### PR TITLE
Add sciPrintf

### DIFF
--- a/drivers/include/obc_sci_io.h
+++ b/drivers/include/obc_sci_io.h
@@ -18,4 +18,14 @@ void initSciMutex(void);
  */
 uint8_t printTextSci(sciBASE_t *sci, unsigned char *text, uint32_t length);
 
+/**
+ * @brief Printf via SCI or SCI2.
+ * 
+ * @param sci The SCI register to use (sciREG or scilinREG)
+ * @param s The format string
+ * @param ... Arguments to use in format string
+ * @return 1 if the entire text was printed, 0 otherwise
+ */
+uint8_t sciPrintf(sciBASE_t *sci, char *s, ...);
+
 #endif /* DRIVERS_INCLUDE_OBC_SCI_IO_H_ */

--- a/drivers/include/obc_sci_io.h
+++ b/drivers/include/obc_sci_io.h
@@ -24,8 +24,8 @@ uint8_t printTextSci(sciBASE_t *sci, unsigned char *text, uint32_t length);
  * @param sci The SCI register to use (sciREG or scilinREG)
  * @param s The format string
  * @param ... Arguments to use in format string
- * @return 1 if the entire text was printed, 0 otherwise
+ * @return 1 if text was printed, 0 otherwise
  */
-uint8_t sciPrintf(sciBASE_t *sci, char *s, ...);
+uint8_t sciPrintf(sciBASE_t *sci, const char *s, ...);
 
 #endif /* DRIVERS_INCLUDE_OBC_SCI_IO_H_ */

--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -6,6 +6,9 @@
 #include <os_task.h>
 
 #include <sci.h>
+#include <stdarg.h>
+
+#define MAX_PRINTF_SIZE 128
 
 static SemaphoreHandle_t sciMutex = NULL;
 static StaticSemaphore_t sciMutexBuffer;
@@ -62,4 +65,16 @@ static void sciSendBytes(sciBASE_t *sci, unsigned char *bytes, uint32_t length) 
         // sciSendByte waits for the transmit buffer to be empty before sending
         sciSendByte(sci, bytes[i]);
     }
+}
+
+uint8_t sciPrintf(sciBASE_t *sci, char *s, ...){
+    va_list args;
+    va_start(args, s);
+
+    char buf[MAX_PRINTF_SIZE];
+    uint8_t n = vsnprintf(buf, MAX_PRINTF_SIZE, s, args);
+
+    uint8_t good = printTextSci(sci, (unsigned char *)buf, MAX_PRINTF_SIZE);
+    good &= n >= 0 && n < MAX_PRINTF_SIZE;
+    return good;
 }

--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -63,6 +63,8 @@ uint8_t printTextSci(sciBASE_t *sci, unsigned char *text, uint32_t length) {
 
 static void sciSendBytes(sciBASE_t *sci, unsigned char *bytes, uint32_t length) {
     for (int i = 0; i < length; i++) {
+        if (bytes[i] == '\0')
+            return;
         // sciSendByte waits for the transmit buffer to be empty before sending
         sciSendByte(sci, bytes[i]);
     }

--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -7,8 +7,9 @@
 
 #include <sci.h>
 #include <stdarg.h>
+#include <stdio.h>
 
-#define MAX_PRINTF_SIZE 128
+#define MAX_PRINTF_SIZE 128U
 
 static SemaphoreHandle_t sciMutex = NULL;
 static StaticSemaphore_t sciMutexBuffer;
@@ -67,14 +68,23 @@ static void sciSendBytes(sciBASE_t *sci, unsigned char *bytes, uint32_t length) 
     }
 }
 
-uint8_t sciPrintf(sciBASE_t *sci, char *s, ...){
+uint8_t sciPrintf(sciBASE_t *sci, const char *s, ...){
+    if (sci == NULL || s == NULL){
+        return 0;
+    }
+
     va_list args;
     va_start(args, s);
 
     char buf[MAX_PRINTF_SIZE];
-    uint8_t n = vsnprintf(buf, MAX_PRINTF_SIZE, s, args);
+    int8_t n = vsnprintf(buf, MAX_PRINTF_SIZE, s, args);
 
-    uint8_t good = printTextSci(sci, (unsigned char *)buf, MAX_PRINTF_SIZE);
-    good &= n >= 0 && n < MAX_PRINTF_SIZE;
-    return good;
+    // n == MAX_PRINTF_SIZE invalid because null character isn't included in count
+    if (n < 0 || n >= MAX_PRINTF_SIZE){
+        // log an error message here
+        return 0;
+    }
+
+    uint8_t ret = printTextSci(sci, (unsigned char *)buf, MAX_PRINTF_SIZE);
+    return ret;
 }

--- a/examples/sci_print_demo/main.c
+++ b/examples/sci_print_demo/main.c
@@ -22,7 +22,7 @@ int main(void) {
         printTextSci(sciREG, (unsigned char *)"Hello from SCI!\r\n", 17);
         
         // Test sciPrintf
-        sciPrintf(scilinREG, "Testing sciPrintf: %d %d %s", 0, 1, "Hello");
+        sciPrintf(scilinREG, "Testing sciPrintf: %d %d %s\r\n", 0, 1, "Hello");
 
         // Toggle the LED.
         gioToggleBit(gioPORTB, 1);

--- a/examples/sci_print_demo/main.c
+++ b/examples/sci_print_demo/main.c
@@ -20,6 +20,9 @@ int main(void) {
         // Note: This will send through the SCITX pin on the LaunchPad; you'll need to 
         // connect an external USB-TTY converter to the LaunchPad to see the text.
         printTextSci(sciREG, (unsigned char *)"Hello from SCI!\r\n", 17);
+        
+        // Test sciPrintf
+        sciPrintf(scilinREG, "Testing sciPrintf: %d %d %s", 0, 1, "Hello");
 
         // Toggle the LED.
         gioToggleBit(gioPORTB, 1);


### PR DESCRIPTION
# Purpose
Adds printf functionality for the serial interface. [Notion ticket](https://www.notion.so/uworbital/Add-serial-printf-function-d99bb06a1f6c40fdaa1ed0f75daf72b9).

# New Changes
Adds `sciPrintf` in `obc_sci_io.c`.

# Testing
- Light testing after changing `printTextSci` to just `printf`.
- Tested valid inputs with different format specifiers (`%s` and `%d`).
- With inputs with strings that overflowed `MAX_PRINTF_SIZE`, sciPrintf does indeed truncate and return `0`.

# Outstanding Changes
Once merged, I will rewrite the ASSERT macro to use `sciPrintf`.
