### PR TITLE
Stop execution when ASSERT fails

### DIFF
--- a/hal/include/sys_common.h
+++ b/hal/include/sys_common.h
@@ -109,6 +109,19 @@ typedef enum config_value_type
 /* will be for procedure arguments.                                             */
 /********************************************************************************/
 
+#ifdef DEBUG
+#define ASSERT(expr) {                                      \
+                         if(!(expr))                        \
+                         {                                  \
+                             __error__(__FILE__, __LINE__); \
+                         }                                  \
+                     }
+#else
+#define ASSERT(expr)
+#endif
+
+/* USER CODE BEGIN (2) */
+
 /**
  * @brief Print information for a failed assertion.
  * @param file File of failed assertion.
@@ -117,18 +130,18 @@ typedef enum config_value_type
  */
 void uartAssertFailed(char *file, int line, char *expr);
 
+#undef ASSERT
 #ifdef DEBUG
 #define ASSERT(expr) {                                                          \
                          if(!(expr))                                            \
                          {                                                      \
                              uartAssertFailed(__FILE__, __LINE__, #expr);       \
+                             while(1);                                          \
                          }                                                      \
                      }
 #else
 #define ASSERT(expr)
 #endif
-
-/* USER CODE BEGIN (2) */
 /* USER CODE END */
 
 /* USER CODE BEGIN (3) */

--- a/hal/include/sys_common.h
+++ b/hal/include/sys_common.h
@@ -49,12 +49,14 @@
 
 #include "hal_stdtypes.h"
 
-#include <string.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 /* USER CODE BEGIN (0) */
+#include <FreeRTOS.h>
+#include <os_task.h>
+
+#include <string.h>
 /* USER CODE END */
 
 /************************************************************/
@@ -108,7 +110,6 @@ typedef enum config_value_type
 /* The ASSERT macro, which does the actual assertion checking.  Typically, this */
 /* will be for procedure arguments.                                             */
 /********************************************************************************/
-
 #ifdef DEBUG
 #define ASSERT(expr) {                                      \
                          if(!(expr))                        \
@@ -136,6 +137,7 @@ void uartAssertFailed(char *file, int line, char *expr);
                          if(!(expr))                                            \
                          {                                                      \
                              uartAssertFailed(__FILE__, __LINE__, #expr);       \
+                             taskDISABLE_INTERRUPTS();                          \
                              while(1);                                          \
                          }                                                      \
                      }


### PR DESCRIPTION
# Purpose
Enter an infinite loop once ASSERT fails and prints an error message as mentioned [here](https://github.com/UWOrbital/OBC-firmware/pull/25#discussion_r1023350544). Furthermore, fixes the bug of [HALCoGen overwriting the ASSERT implementation](https://www.notion.so/uworbital/BUG-Generating-HAL-deletes-custom-ASSERT-macro-implementation-2f9136c3b7594cccbc3044a55a8afbea).
