### PR TITLE
Update Makefile to remove sys_main.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,6 @@ $(BUILD_DIR)/OBC-firmware.out: $(OBJS)
 
 clean:
 	rm -rf build/*
+	rm -f hal/source/sys_main.c
 
 .PHONY: all clean


### PR DESCRIPTION
# Purpose
This PR updates the Makefile to remove `hal/source/sys_main.c` when the `clean` target is run.

Whenever code is generated by HALCoGen, the sys_main.c file is also generated with its own main function. This causes a compiler error because we already have a main function in our main.c file. We should update the clean target in our Makefile to remove sys_main.c.

[Notion doc](https://www.notion.so/uworbital/Update-Makefile-to-remove-sys_main-c-1c48540bdf1f4c30bcc21061a297faaa)

# New Changes
- Updated the `clean` target of the `Makefile`

# Testing
- Created a test `hal/source/sys_main.c` file and then ran `make clean`. The `hal/source/sys_main.c` file was removed.

# Outstanding Changes
