### PR TITLE
Fixed elif defines of board type

### DIFF
--- a/drivers/source/obc_sci_io.c
+++ b/drivers/source/obc_sci_io.c
@@ -16,10 +16,10 @@
 #ifdef RM46_LAUNCHPAD
 	#define UART_PRINT_REG scilinREG
 	#define UART_READ_REG scilinREG 
-#elif OBC_REVISION_1
+#elif defined(OBC_REVISION_1)
 	#define UART_PRINT_REG sciREG 
 	#define UART_READ_REG sciREG
-#elif OBC_REVISION_2
+#elif defined(OBC_REVISION_2)
 	#error Serial port not yet chosen for OBC_REVISION_2
 #else
 	#error Board not defined


### PR DESCRIPTION
# Purpose
Fixed possible sci bug with board type defines

# New Changes
Added defined() to the #elif of OBC_REV_1 and OBC_REV_2.
