### PR TITLE
Added spiDataFormat argument to spi helper functions

### DIFF
--- a/drivers/include/obc_spi_io.h
+++ b/drivers/include/obc_spi_io.h
@@ -32,11 +32,12 @@ obc_error_code_t assertChipSelect(gioPORT_t *spiPort, uint8_t csNum);
 /**
  * @brief Send and receive a byte via SPI.
  * @param spiReg The SPI register to use.
+ * @param spiDataFormat The SPI data format options.
  * @param outb The byte to send.
  * @param inb Buffer to store the received byte.
  * @return Error code. OBC_ERR_CODE_SUCCESS if successful.
  */
-obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, uint8_t outb, uint8_t *inb);
+obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat, uint8_t outb, uint8_t *inb);
 
 /**
  * @brief Send a byte via SPI.
@@ -45,7 +46,7 @@ obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, uint8_t outb, uint
  * @param outb The byte to send.
  * @return Error code. OBC_ERR_CODE_SUCCESS if successful.
  */
-obc_error_code_t spiTransmitByte(spiBASE_t *spiReg, uint8_t outb);
+obc_error_code_t spiTransmitByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat, uint8_t outb);
 
 /**
  * @brief Receive a byte via SPI.
@@ -54,6 +55,6 @@ obc_error_code_t spiTransmitByte(spiBASE_t *spiReg, uint8_t outb);
  * @param inb Buffer to store the received byte.
  * @return Error code. OBC_ERR_CODE_SUCCESS if successful.
  */
-obc_error_code_t spiReceiveByte(spiBASE_t *spiReg, uint8_t *inb);
+obc_error_code_t spiReceiveByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat, uint8_t *inb);
 
 #endif // DRIVERS_INCLUDE_OBC_SPI_IO_H_

--- a/drivers/source/obc_spi_io.c
+++ b/drivers/source/obc_spi_io.c
@@ -96,8 +96,11 @@ obc_error_code_t assertChipSelect(gioPORT_t *spiPort, uint8_t csNum) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
 }
 
-obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, uint8_t outb, uint8_t *inb) {
+obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat,uint8_t outb, uint8_t *inb) {
     if (spiReg == NULL)
+        return OBC_ERR_CODE_INVALID_ARG;
+
+    if (spiDataFormat == NULL)
         return OBC_ERR_CODE_INVALID_ARG;
 
     if (inb == NULL)
@@ -108,13 +111,11 @@ obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, uint8_t outb, uint
         return OBC_ERR_CODE_INVALID_ARG;
 
     if (xSemaphoreTake(spiMutexes[spiRegIndex], portMAX_DELAY) == pdTRUE) {        
-        spiDAT1_t spiData = {0};
-
         // The SPI HAL functions take 16-bit arguments, but we're using 8-bit word size
         uint16_t spiWordOut = (uint16_t)outb;
         uint16_t spiWordIn;
 
-        uint32_t spiErr = spiTransmitAndReceiveData(spiReg, &spiData, 1, &spiWordOut, &spiWordIn) & SPI_FLAG_ERR_MASK;
+        uint32_t spiErr = spiTransmitAndReceiveData(spiReg, spiDataFormat, 1, &spiWordOut, &spiWordIn) & SPI_FLAG_ERR_MASK;
         obc_error_code_t ret;
 
         if (spiErr != SPI_FLAG_SUCCESS) {
@@ -131,17 +132,17 @@ obc_error_code_t spiTransmitAndReceiveByte(spiBASE_t *spiReg, uint8_t outb, uint
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
 }
 
-obc_error_code_t spiTransmitByte(spiBASE_t *spiReg, uint8_t outb) {
+obc_error_code_t spiTransmitByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat,uint8_t outb) {
     obc_error_code_t errCode;
     uint8_t inb;
 
-    RETURN_IF_ERROR_CODE(spiTransmitAndReceiveByte(spiReg, outb, &inb));
+    RETURN_IF_ERROR_CODE(spiTransmitAndReceiveByte(spiReg, spiDataFormat, outb, &inb));
     return OBC_ERR_CODE_SUCCESS;
 }
 
-obc_error_code_t spiReceiveByte(spiBASE_t *spiReg, uint8_t *inb) {
+obc_error_code_t spiReceiveByte(spiBASE_t *spiReg, spiDAT1_t *spiDataFormat, uint8_t *inb) {
     obc_error_code_t errCode;
-    RETURN_IF_ERROR_CODE(spiTransmitAndReceiveByte(spiReg, 0xFF, inb));
+    RETURN_IF_ERROR_CODE(spiTransmitAndReceiveByte(spiReg, spiDataFormat, 0xFF, inb));
     return OBC_ERR_CODE_SUCCESS;
 }
 


### PR DESCRIPTION
# Purpose
Add ability to specify SPI data format when transmitting and receiving data.

# New Changes
- Added SPI data format argument to SPI transmit and receive functions
- Removed default SPI data format used.

# Testing
- Compiled to check if change is valid
