### PR TITLE
Bring-up Utility: I2C

### DIFF
--- a/drivers/common/include/obc_i2c_io.h
+++ b/drivers/common/include/obc_i2c_io.h
@@ -31,7 +31,7 @@ obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf);
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out, 
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, void *buf);
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf);
 
 /**
  * @brief Read byte(s) from a device's register(s).

--- a/drivers/common/include/obc_i2c_io.h
+++ b/drivers/common/include/obc_i2c_io.h
@@ -21,7 +21,7 @@ void initI2CMutex(void);
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out, 
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, void *buf);
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf);
 
 /**
  * @brief Receive a buffer of bytes from a device on the I2C bus

--- a/drivers/common/source/obc_i2c_io.c
+++ b/drivers/common/source/obc_i2c_io.c
@@ -33,7 +33,7 @@ void initI2CMutex(void) {
     ASSERT(i2cMutex != NULL);
 }
 
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, void *buf) {
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf) {
     ASSERT(i2cMutex != NULL);
 
     if (buf == NULL || size < 1)

--- a/drivers/common/source/obc_i2c_io.c
+++ b/drivers/common/source/obc_i2c_io.c
@@ -69,7 +69,7 @@ obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
 }
 
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, void *buf) {
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf) {
     ASSERT(i2cMutex != NULL);
 
     if (buf == NULL || size < 1)

--- a/util/bringup/interface_tests/source/test_i2c.c
+++ b/util/bringup/interface_tests/source/test_i2c.c
@@ -10,5 +10,5 @@ void testI2C(void) {
         sciPrintf("Failed sending mesage through I2C\r\n");
         return;
     }
-    sciPrintf("Successfully sending message through I2C...\r\n");
+    sciPrintf("Successfully sending message (0xff, 0x00, 0xff) through I2C...\r\n");
 }

--- a/util/bringup/interface_tests/source/test_i2c.c
+++ b/util/bringup/interface_tests/source/test_i2c.c
@@ -7,7 +7,9 @@ void testI2C(void) {
     uint8_t messageData[] = {0xff, 0x00, 0xff};
     if(i2cSendTo(0x00, 3, messageData) != OBC_ERR_CODE_SUCCESS)
     {
-        sciPrintf("Failed sending mesage through I2C\r\n");
+        sciPrintf("Failed sending message through I2C\r\n"
+                  "The failure might because no I2C slave device at address 0x00, "
+                  "no actual data bytes are sent since no acknowledgement from I2C slave device\r\n");
         return;
     }
     sciPrintf("Successfully sending message (0xff, 0x00, 0xff) through I2C...\r\n");

--- a/util/bringup/interface_tests/source/test_i2c.c
+++ b/util/bringup/interface_tests/source/test_i2c.c
@@ -1,6 +1,14 @@
 #include "test_i2c.h"
 #include "obc_sci_io.h"
+#include "obc_i2c_io.h"
 
 void testI2C(void) {
     sciPrintf("Testing I2C...\r\n");
+    uint8_t messageData[] = {0xff, 0x00, 0xff};
+    if(i2cSendTo(0x00, 3, messageData) != OBC_ERR_CODE_SUCCESS)
+    {
+        sciPrintf("Failed sending mesage through I2C\r\n");
+        return;
+    }
+    sciPrintf("Successfully sending message through I2C...\r\n");
 }


### PR DESCRIPTION

# Purpose
Test if we could send message successfully through I2C

# New Changes
Implement the I2C utility bring up; Change the i2cSendTo function's parameter type from void * to uint8 *

# Testing
- the code can be made successfully after change

# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
