### PR TITLE
[sw watchdog] Replaced macros with definitions from HAL

### DIFF
--- a/common/include/obc_privilege.h
+++ b/common/include/obc_privilege.h
@@ -1,7 +1,8 @@
 #ifndef COMMON_INCLUDE_OBC_PRIVILEGE_H_
 #define COMMON_INCLUDE_OBC_PRIVILEGE_H_
 
-#include "os_portmacro.h"
+#include <FreeRTOS.h>
+#include <os_portmacro.h>
 
 /**
  * @brief Set processor to privileged mode

--- a/drivers/common/source/obc_sw_watchdog.c
+++ b/drivers/common/source/obc_sw_watchdog.c
@@ -7,6 +7,8 @@
 #include <reg_rti.h>
 #include <rti.h>
 
+#include <stdint.h>
+
 // Watchdog is fed by writing these two values to the WDKEY register
 #define RESET_DWD_CMD1 0xE51AUL
 #define RESET_DWD_CMD2 0xA35CUL


### PR DESCRIPTION
# Purpose
Removed some custom macros with stuff already defined in the HAL