### PR TITLE
Enabled stack protection against buffer overflow attacks

### DIFF
--- a/drivers/common/include/obc_reset.h
+++ b/drivers/common/include/obc_reset.h
@@ -8,6 +8,7 @@ typedef enum {
     RESET_REASON_TESTING,               // For testing purposes
     RESET_REASON_CMD_EXEC_OBC_RESET,    // Reset due to command execution 
     RESET_REASON_FS_FAILURE,            // File system operation failed
+    RESET_REASON_STACK_CHECK_FAIL,      // Stack canary check failed
 } obc_reset_reason_t;
 
 /**

--- a/global_vars.mk
+++ b/global_vars.mk
@@ -25,6 +25,7 @@ CC_FLAGS += -gdwarf-3
 CC_FLAGS += -gstrict-dwarf
 CC_FLAGS += -Wall
 CC_FLAGS += -Wextra
+CC_FLAGS += -fstack-protector-strong
 CC_FLAGS += -Wno-unused-parameter
 # CC_FLAGS += -Werror TODO: Enable this if we solve all hal warnings
 

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include "obc_sci_io.h"
 #include "obc_i2c_io.h"
 #include "obc_spi_io.h"
+#include "obc_reset.h"
 
 #include <FreeRTOS.h>
 #include <os_task.h>
@@ -13,6 +14,15 @@
 #include <i2c.h>
 #include <spi.h>
 #include <can.h>
+
+// This is the stack canary. It should never be overwritten.
+// Ideally, it would be a random value, but we don't have a good source of entropy
+// that we can use.
+void *__stack_chk_guard = (void *)0xDEADBEEF;
+
+void __stack_chk_fail(void) {
+    resetSystem(RESET_REASON_STACK_CHECK_FAIL);
+}
 
 int main(void) {
 


### PR DESCRIPTION
# Purpose
Enabled compiler flag which inserts a guard variable onto the stack frame for each vulnerable function. Based on the flag I'm using, a function is vulnerable if it contains:
- An array of any size and type.
- A call to alloca().
- A local variable that has its address taken.

![image](https://user-images.githubusercontent.com/63618806/233981563-6ee22a1b-9c5d-496f-9732-6b0bd90dcc3f.png)

Note: this does not make you vulnerable to buffer overflow attacks. An attacker can still overwrite local function variables (like a function pointer or array index) and do harm that way. The non-random canary value isn't ideal either. We _could_ use a pseudorandom number tho.