### PR TITLE
Set telemetry ID #0 as invalid

### DIFF
--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -9,7 +9,7 @@
 
 typedef enum {
     /* Used to indicate that the telemetry data is invalid.
-       It should not have an pack function. */
+       It should not have a pack function. */
     TELEM_NONE = 0,
 
     // Temperature values

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -8,6 +8,10 @@
 #include <stddef.h>
 
 typedef enum {
+    /* Used to indicate that the telemetry data is invalid.
+       It should not have an pack function. */
+    TELEM_NONE = 0,
+
     // Temperature values
     TELEM_CC1120_TEMP,
     TELEM_COMMS_CUSTOM_TRANSCEIVER_TEMP,


### PR DESCRIPTION
# Purpose
Telemetry ID 0 is now invalid. This was done since Comms will be packing the end of telemetry packets with 0s.