### PR TITLE
Set command ID #0 as invalid

### DIFF
--- a/cdh/include/command_id.h
+++ b/cdh/include/command_id.h
@@ -4,10 +4,17 @@
 #include "obc_assert.h"
 #include <stdint.h>
 
-// Command IDs
-#define CMD_EXEC_OBC_RESET              (uint8_t) 0
-#define CMD_RTC_SYNC                    (uint8_t) 1
-#define CMD_DOWNLINK_LOGS_NEXT_PASS     (uint8_t) 2
+/*--------------------------*/
+/*   Command ID Definitions */
+/*--------------------------*/
+
+/* Used to indicate that the command is invalid.
+   It should not have an unpack function. */
+#define CMD_NONE                        (uint8_t) 0
+
+#define CMD_EXEC_OBC_RESET              (uint8_t) 1
+#define CMD_RTC_SYNC                    (uint8_t) 2
+#define CMD_DOWNLINK_LOGS_NEXT_PASS     (uint8_t) 3
 
 
 #endif // CDH_INCLUDE_COMMAND_ID_H_

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -9,7 +9,7 @@
 
 typedef enum {
     /* Used to indicate that the telemetry data is invalid.
-       It should not have an pack function. */
+       It should not have a pack function. */
     TELEM_NONE = 0,
 
     // Temperature values

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -8,6 +8,10 @@
 #include <stddef.h>
 
 typedef enum {
+    /* Used to indicate that the telemetry data is invalid.
+       It should not have an pack function. */
+    TELEM_NONE = 0,
+
     // Temperature values
     TELEM_CC1120_TEMP,
     TELEM_COMMS_CUSTOM_TRANSCEIVER_TEMP,

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -8,10 +8,6 @@
 #include <stddef.h>
 
 typedef enum {
-    /* Used to indicate that the telemetry data is invalid.
-       It should not have a pack function. */
-    TELEM_NONE = 0,
-
     // Temperature values
     TELEM_CC1120_TEMP,
     TELEM_COMMS_CUSTOM_TRANSCEIVER_TEMP,


### PR DESCRIPTION
# Purpose
Command ID 0 is now invalid. This was done since Comms will be packing the end of command packets with 0s.