### PR TITLE
Add telemetry downlink command

### DIFF
--- a/cdh/include/command_callbacks.h
+++ b/cdh/include/command_callbacks.h
@@ -4,6 +4,9 @@
 #include "obc_errors.h"
 #include "command_data.h"
 
+#define SECONDS_TO_HOURS 3600
+#define SECONDS_TO_MINS 60
+
 typedef obc_error_code_t (*cmd_callback_t)(cmd_msg_t *);
 
 /* Declare all command callbacks below */
@@ -16,5 +19,8 @@ obc_error_code_t rtcSyncCmdCallback(cmd_msg_t *cmd);
 
 // CMD_DOWNLINK_LOGS_NEXT_PASS
 obc_error_code_t downlinkLogsNextPassCmdCallback(cmd_msg_t *cmd);
+
+// CMD_DOWNLINK_TELEMETRY
+obc_error_code_t downlinkTelemetryCmdCallback(cmd_msg_t *cmd);
 
 #endif // CDH_INCLUDE_COMMAND_CALLBACKS_H_

--- a/cdh/include/command_data.h
+++ b/cdh/include/command_data.h
@@ -2,6 +2,7 @@
 #define CDH_INCLUDE_COMMAND_DATA_H_
 
 #include "obc_logging.h"
+#include "telemetry_manager.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -19,7 +20,6 @@ typedef struct {
 typedef struct {
     log_level_t logLevel;
 } downlink_logs_next_pass_cmd_data_t;
-
 
 /* -------------------------- */
 /*   Command Message Struct   */

--- a/cdh/include/command_id.h
+++ b/cdh/include/command_id.h
@@ -36,5 +36,6 @@ typedef enum {
 #define CMD_EXEC_OBC_RESET              (uint8_t) 1
 #define CMD_RTC_SYNC                    (uint8_t) 2
 #define CMD_DOWNLINK_LOGS_NEXT_PASS     (uint8_t) 3
+#define CMD_DOWNLINK_TELEMETRY          (uint8_t) 4
 
 #endif // CDH_INCLUDE_COMMAND_ID_H_

--- a/cdh/include/command_unpack.h
+++ b/cdh/include/command_unpack.h
@@ -17,4 +17,7 @@ void unpackRtcSyncCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* ms
 // CMD_DOWNLINK_LOGS_NEXT_PASS
 void unpackDownlinkLogsNextPassCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* msg);
 
+// CMD_DOWNLINK_TELEMETRY
+void unpackDownlinTelemetryCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* msg);
+
 #endif // CDH_INCLUDE_COMMAND_UNPACK_H_

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -87,6 +87,15 @@ typedef struct {
     
 } telemetry_data_t;
 
+typedef enum {
+    DATA_EVENT,
+    DOWNLINK_EVENT,
+} telemetry_event_id_t;
+
+typedef struct {
+    telemetry_data_t data;
+    telemetry_event_id_t id;
+} telemetry_event_t;
 #define MAX_TELEMETRY_DATA_SIZE sizeof(telemetry_data_t)
 
 #define BIT_0 (1 << 0)

--- a/cdh/include/telemetry_manager.h
+++ b/cdh/include/telemetry_manager.h
@@ -89,6 +89,8 @@ typedef struct {
 
 #define MAX_TELEMETRY_DATA_SIZE sizeof(telemetry_data_t)
 
+#define BIT_0 (1 << 0)
+
 /**
  * @brief	Initialize the telemetry task and associated FreeRTOS constructs (queues, timers, etc.)
  */
@@ -100,5 +102,11 @@ void initTelemetry(void);
  * @return  obc_error_code_t OBC_ERR_CODE_SUCCESS if the data was added to the queue, error code otherwise
  */
 obc_error_code_t addTelemetryData(telemetry_data_t *data);
+
+/**
+ * @brief	Sends downlink telemetry event to telemetry manager by setting BIT0
+ * @return  obc_error_code_t OBC_ERR_CODE_SUCCESS if the data was added to the queue, error code otherwise
+ */
+obc_error_code_t sendDownlinkTelemetryEvent(void);
 
 #endif /* CDH_INCLUDE_TELEMETRY_H_ */

--- a/cdh/source/command_callbacks.c
+++ b/cdh/source/command_callbacks.c
@@ -1,9 +1,13 @@
 #include "command_callbacks.h"
 #include "command_data.h"
+#include "comms_manager.h"
+#include "ds3232_mz.h"
 #include "obc_reset.h"
 #include "obc_errors.h"
 #include "obc_logging.h"
+#include "obc_time.h"
 
+#include <FreeRTOS.h>
 #include <stddef.h>
 
 obc_error_code_t execObcResetCmdCallback(cmd_msg_t *cmd) {
@@ -24,7 +28,13 @@ obc_error_code_t rtcSyncCmdCallback(cmd_msg_t *cmd) {
         return OBC_ERR_CODE_INVALID_ARG;
     }
     
-    // TODO: Implement handling for this command
+    // Update RTC and Unix Time
+    uint32_t timeRTC = cmd->timestamp;
+    setSecondsRTC(timeRTC / SECONDS_TO_HOURS);
+    setMinutesRTC((timeRTC % SECONDS_TO_HOURS) / SECONDS_TO_MINS);
+    setHourRTC(timeRTC % SECONDS_TO_MINS);
+    setCurrentUnixTime(cmd->rtcSync.unixTime);
+
     LOG_DEBUG("Executing RTC sync command - time %lu", cmd->rtcSync.unixTime);
     return OBC_ERR_CODE_SUCCESS;
 }
@@ -36,5 +46,18 @@ obc_error_code_t downlinkLogsNextPassCmdCallback(cmd_msg_t *cmd) {
 
     // TODO: Implement handling for this command
     LOG_DEBUG("Executing log downlink command - log level %u", cmd->downlinkLogsNextPass.logLevel);
+    return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t downlinkTelemetryCmdCallback(cmd_msg_t *cmd) {
+    if(cmd == NULL) {
+        return OBC_ERR_CODE_INVALID_ARG;
+    }
+
+    if(sendDownlinkTelemetryEvent() != OBC_ERR_CODE_SUCCESS) {
+        return OBC_ERR_CODE_UNKNOWN;
+    }
+
+    LOG_DEBUG("Executing telemetry downlink command");
     return OBC_ERR_CODE_SUCCESS;
 }

--- a/cdh/source/command_unpack.c
+++ b/cdh/source/command_unpack.c
@@ -66,3 +66,8 @@ void unpackRtcSyncCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* cm
 void unpackDownlinkLogsNextPassCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* cmdMsg) {
     cmdMsg->downlinkLogsNextPass.logLevel = (log_level_t)unpackUint8(buffer, offset);
 }
+
+// CMD_DOWNLINK_TELEMETRY
+void unpackDownlinkTelemetryCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* cmdMsg) {
+    // No data to unpack
+}

--- a/cdh/source/telemetry_manager.c
+++ b/cdh/source/telemetry_manager.c
@@ -21,9 +21,9 @@
 #include <string.h>
 
 /* Telemetry data queue config */
-#define TELEMETRY_DATA_QUEUE_LENGTH 128U
-#define TELEMETRY_DATA_QUEUE_ITEM_SIZE sizeof(telemetry_data_t)
-#define TELEMETRY_DATA_QUEUE_WAIT_PERIOD pdMS_TO_TICKS(1000)
+#define TELEMETRY_EVENT_QUEUE_LENGTH 128U
+#define TELEMETRY_EVENT_QUEUE_ITEM_SIZE sizeof(telemetry_event_t)
+#define TELEMETRY_EVENT_QUEUE_WAIT_PERIOD pdMS_TO_TICKS(1000)
 
 #define STARTING_TELEMETRY_BATCH_ID 0UL
 
@@ -44,34 +44,24 @@ static StaticTask_t telemetryTaskBuffer;
 static StackType_t telemetryTaskStack[TELEMETRY_STACK_SIZE];
 
 // Telemetry Data Queue
-static QueueHandle_t telemetryDataQueueHandle = NULL;
-static StaticQueue_t telemetryDataQueue;
-static uint8_t telemetryDataQueueStack[TELEMETRY_DATA_QUEUE_LENGTH*TELEMETRY_DATA_QUEUE_ITEM_SIZE];
+static QueueHandle_t telemetryEventQueueHandle = NULL;
+static StaticQueue_t telemetryEventQueue;
+static uint8_t telemetryEventQueueStack[TELEMETRY_EVENT_QUEUE_LENGTH*TELEMETRY_EVENT_QUEUE_ITEM_SIZE];
 
-// Telemetry Events Group
-static QueueHandle_t telemetryEventsQueueHandle = NULL;
-static StaticQueue_t telemetryEventsQueue;
-static uint8_t telemetryEventsQueueStack[TELEMETRY_DATA_QUEUE_LENGTH*TELEMETRY_DATA_QUEUE_ITEM_SIZE];
 static uint32_t BatchId;
 
 void initTelemetry(void) {
     memset(&telemetryTaskBuffer, 0, sizeof(telemetryTaskBuffer));
     memset(&telemetryTaskStack, 0, sizeof(telemetryTaskStack));
 
-    memset(&telemetryDataQueue, 0, sizeof(telemetryDataQueue));
-    memset(&telemetryDataQueueStack, 0, sizeof(telemetryDataQueueStack));
-
-    memset(&telemetryEventsQueue, 0, sizeof(telemetryEventsQueue));
-    memset(&telemetryEventsQueueStack, 0, sizeof(telemetryEventsQueueStack));
+    memset(&telemetryEventQueue, 0, sizeof(telemetryEventQueue));
+    memset(&telemetryEventQueueStack, 0, sizeof(telemetryEventQueueStack));
 
     ASSERT( (telemetryTaskStack != NULL) && (&telemetryTaskBuffer != NULL) );
     telemetryTaskHandle = xTaskCreateStatic(telemetryManager, TELEMETRY_NAME, TELEMETRY_STACK_SIZE, NULL, TELEMETRY_PRIORITY, telemetryTaskStack, &telemetryTaskBuffer);
 
-    ASSERT( (telemetryDataQueueStack != NULL) && (&telemetryDataQueue != NULL) );
-    telemetryDataQueueHandle = xQueueCreateStatic(TELEMETRY_DATA_QUEUE_LENGTH, TELEMETRY_DATA_QUEUE_ITEM_SIZE, telemetryDataQueueStack, &telemetryDataQueue);
-
-    ASSERT( (telemetryEventsQueueStack != NULL) && (&telemetryEventsQueue != NULL) );
-    telemetryEventsQueueHandle = xQueueCreateStatic(TELEMETRY_DATA_QUEUE_LENGTH, TELEMETRY_DATA_QUEUE_ITEM_SIZE, telemetryEventsQueueStack, &telemetryEventsQueue);
+    ASSERT( (telemetryEventQueueStack != NULL) && (&telemetryEventQueue != NULL) );
+    telemetryEventQueueHandle = xQueueCreateStatic(TELEMETRY_EVENT_QUEUE_LENGTH, TELEMETRY_EVENT_QUEUE_ITEM_SIZE, telemetryEventQueueStack, &telemetryEventQueue);
 }
 
 static void telemetryManager(void * pvParameters) {
@@ -89,51 +79,56 @@ static void telemetryManager(void * pvParameters) {
     BatchId = telemetryBatchId;
 
     while (1) {
-        telemetry_data_t telemData;
-        if (xQueueReceive(telemetryDataQueueHandle, &telemData, TELEMETRY_DATA_QUEUE_WAIT_PERIOD) == pdPASS) {
+        telemetry_event_t telemEvent;
+        telemetry_event_id_t telemEventId;
+        if (xQueueReceive(telemetryEventQueueHandle, &telemEvent, TELEMETRY_EVENT_QUEUE_WAIT_PERIOD) != pdPASS) {
             // TODO: Deal with errors
-            LOG_IF_ERROR_CODE(writeTelemetryToFile(telemetryFileId, telemData));
-        }
-
-        // Check if we need to downlink telemetry
-        // TODO: This is a mock implementation. We need to implement a proper alarm system
-        if (!checkDownlinkAlarm()) {
             continue;
         }
-
-        // Important to close the file before sending it to the comms task
-        LOG_IF_ERROR_CODE(closeTelemetryFile(telemetryFileId));
-        if (errCode != OBC_ERR_CODE_SUCCESS) {
-            // TODO: Handle this error
-        }
-
-        // Send downlink event when event is received by telemetry manager
-        comms_event_t downlinkEvent;
-        if(xQueueReceive(telemetryEventsQueueHandle, &downlinkEvent, TELEMETRY_DATA_QUEUE_WAIT_PERIOD) == pdPASS) {
-            LOG_IF_ERROR_CODE(sendToCommsQueue(&downlinkEvent));
-        }
-
-
-        if (errCode != OBC_ERR_CODE_SUCCESS) {
-            // TODO: Handle this error, specifically if the queue is full. Other
-            // errors should be caught during testing.
-        }
-
-        // The lifetime of the CubeSat should not allow for this to overflow.
-        // However, if it does, we can wrap around to 0 and start overwriting old files.
-        telemetryBatchId++;
         
-        // TODO: Save batch ID to FRAM
+        switch(telemEvent.id){
+            case DATA_EVENT:
+                LOG_IF_ERROR_CODE(writeTelemetryToFile(telemetryFileId, telemEvent.data));
+                // Important to close the file before sending it to the comms task
+                LOG_IF_ERROR_CODE(closeTelemetryFile(telemetryFileId));
+                if (errCode != OBC_ERR_CODE_SUCCESS) {
+                    // TODO: Handle this error
+                }
+                // The lifetime of the CubeSat should not allow for this to overflow.
+                // However, if it does, we can wrap around to 0 and start overwriting old files.
+                telemetryBatchId++;
+                
+                // TODO: Save batch ID to FRAM
 
-        LOG_IF_ERROR_CODE(createAndOpenTelemetryFileRW(telemetryBatchId, &telemetryFileId));
-        if (errCode != OBC_ERR_CODE_SUCCESS) {
-            // TODO: Deal with errors
+                LOG_IF_ERROR_CODE(createAndOpenTelemetryFileRW(telemetryBatchId, &telemetryFileId));
+                if (errCode != OBC_ERR_CODE_SUCCESS) {
+                    // TODO: Deal with errors
+                }
+                break;
+            case DOWNLINK_EVENT:
+                // Send downlink event when event is received by telemetry manager
+                comms_event_t downlinkEvent = {.eventID = DOWNLINK_TELEMETRY, .telemetryBatchId = BatchId};
+                LOG_IF_ERROR_CODE(sendToCommsQueue(&downlinkEvent));
+                if (errCode != OBC_ERR_CODE_SUCCESS) {
+                    // TODO: Handle this error, specifically if the queue is full. Other
+                    // errors should be caught during testing.
+                }
+                break;
+            default:
+                // TODO: Handle unknown events
         }
+        
+        // // Check if we need to downlink telemetry
+        // // TODO: This is a mock implementation. We need to implement a proper alarm system
+        // if (!checkDownlinkAlarm()) {
+        //     continue;
+        // }
     }
 }
 
 obc_error_code_t addTelemetryData(telemetry_data_t *data) {
-    if (telemetryDataQueueHandle == NULL) {
+    telemetry_event_t telemEvent = {0};
+    if (telemetryEventQueueHandle == NULL) {
         return OBC_ERR_CODE_INVALID_STATE;
     }
 
@@ -141,7 +136,10 @@ obc_error_code_t addTelemetryData(telemetry_data_t *data) {
         return OBC_ERR_CODE_INVALID_ARG;
     }
 
-    if (xQueueSend(telemetryDataQueueHandle, (void *) data, TELEMETRY_DATA_QUEUE_WAIT_PERIOD) == pdPASS) {
+    telemEvent.id = DATA_EVENT;
+    memcpy(&telemEvent.data, data, sizeof(telemetry_data_t));
+
+    if (xQueueSend(telemetryEventQueueHandle, &telemEvent, TELEMETRY_EVENT_QUEUE_WAIT_PERIOD) == pdPASS) {
         return OBC_ERR_CODE_SUCCESS;
     }
     
@@ -161,8 +159,9 @@ static bool checkDownlinkAlarm(void) {
 }
 
 obc_error_code_t sendDownlinkTelemetryEvent(void) {
-    comms_event_t downlinkEvent = {.eventID = DOWNLINK_TELEMETRY, .telemetryBatchId = BatchId};
-    if(xQueueSend(telemetryEventsQueueHandle, &downlinkEvent, TELEMETRY_DATA_QUEUE_WAIT_PERIOD) == pdPASS) {
+    telemetry_event_t downlinkEvent = {0};
+    downlinkEvent.id = DOWNLINK_EVENT;
+    if(xQueueSend(telemetryEventQueueHandle, &downlinkEvent, TELEMETRY_EVENT_QUEUE_WAIT_PERIOD) == pdPASS) {
         return OBC_ERR_CODE_SUCCESS;
     }
 


### PR DESCRIPTION
# Purpose
Addressed todo and added telemetry downlink command

# New Changes
- RTC and unix time updated for todo
- Telemetry downlink command added

# Notes
- Initially was trying to use xEventGroupCreate and set a bit to indicate telemetry downlink event but the FreeRTOS library was not acknowledging the structs used from it, so switched to using queue similar to current use (Note: we likely won't need a queue because only one event is actually used currently and the size is meant to be for telemetry data entries, which are much larger). Alternatives?


