### PR TITLE
Removed useless extern

### DIFF
--- a/interfaces/obc_gs_interface/fec/obc_gs_fec.c
+++ b/interfaces/obc_gs_interface/fec/obc_gs_fec.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-correct_reed_solomon *rs = NULL;
+static correct_reed_solomon *rs = NULL;
 
 /**
  * @brief takes in a packed telemtry array and encodes it using reed solomon

--- a/interfaces/obc_gs_interface/fec/obc_gs_fec.h
+++ b/interfaces/obc_gs_interface/fec/obc_gs_fec.h
@@ -9,8 +9,6 @@
 #define RS_ENCODED_SIZE 255U
 #define PACKED_TELEM_PACKET_SIZE RS_DECODED_SIZE
 
-extern correct_reed_solomon *rs;
-
 typedef struct {
   uint8_t data[RS_ENCODED_SIZE];
 } packed_rs_packet_t;


### PR DESCRIPTION
# Purpose
Removed a useless `extern` variable that was in a header file.

# Testing
- CI
- Tested demo on board (with mutex take/release commented out in `sciSendBytes`)