### PR TITLE
Removed unnecessary paths from pre-commit exclude list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
     rev: v3.2.0
     hooks:
     - id: trailing-whitespace
-      exclude: '(build|build_arm|libs|hal)/.*'
+      exclude: '(libs|hal)/.*'
     - id: end-of-file-fixer
-      exclude: '(build|build_arm|libs|hal)/.*'
+      exclude: '(libs|hal)/.*'
     - id: check-added-large-files
-      exclude: '(build|build_arm|libs|hal)/.*'
+      exclude: '(libs|hal)/.*'
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:
     - id: clang-format
       types_or: [c++, c]
-      exclude: '(build|build_arm|libs|hal)/.*'
+      exclude: '(libs|hal)/.*'


### PR DESCRIPTION
# Purpose
pre-commit will only run on files that can be added by Git. So there's no need to add the build paths in the pre-commit config file since those paths are already in `.gitignore`.

# Testing
- Ran `pre-commit run --all-files` locally to make sure pre-commit doesn't run on the build files.