### PR TITLE
[BUGFIX] CC1120 TX Semaphores Not Correctly Initialized

### DIFF
--- a/obc/drivers/cc1120/cc1120_txrx.c
+++ b/obc/drivers/cc1120/cc1120_txrx.c
@@ -92,12 +92,16 @@ static register_setting_t cc1120SettingsExt[] = {
 void initAllTxRxSemaphores(void) {
   if (txSemaphore == NULL) {
     txSemaphore = xSemaphoreCreateBinaryStatic(&txSemaphoreBuffer);
+    // Initialize semaphore with count of 1
+    xSemaphoreGive(txSemaphore);
   }
   if (rxSemaphore == NULL) {
     rxSemaphore = xSemaphoreCreateBinaryStatic(&rxSemaphoreBuffer);
   }
   if (txFifoEmptySemaphore == NULL) {
     txFifoEmptySemaphore = xSemaphoreCreateBinaryStatic(&txFifoEmptySemaphoreBuffer);
+    // Initialize semaphore with count of 1
+    xSemaphoreGive(txFifoEmptySemaphore);
   }
   if (syncReceivedSemaphore == NULL) {
     syncReceivedSemaphore = xSemaphoreCreateBinaryStatic(&syncReceivedSemaphoreBuffer);


### PR DESCRIPTION
# Purpose
Explain the purpose of the PR here, including references to any existing Notion tasks.
- Both of the TX semaphores for cc1120 need to be initialized with a value of 1 otherwise we will never be able to transmit
# New Changes
- Explain new changes

# Testing
- Explain tests that you ran to verify code functionality.
- CI
# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
