### PR TITLE
initialized ret to 0 to prevent short circuit optimization

### DIFF
--- a/obc/reliance_edge/os/freertos/services/osbdev_fatfs.h
+++ b/obc/reliance_edge/os/freertos/services/osbdev_fatfs.h
@@ -107,7 +107,7 @@ static REDSTATUS DiskClose(uint8_t bVolNum) {
     @retval -RED_EIO    A disk I/O or driver error occurred.
 */
 static REDSTATUS DiskGetGeometry(uint8_t bVolNum, BDEVINFO *pInfo) {
-  REDSTATUS ret;
+  REDSTATUS ret = 0;
   uint16_t wSectorSize;
   uint32_t dwSectorCount;
   DRESULT result;


### PR DESCRIPTION
# Purpose
Fix issue where sd card format would fail.

# New Changes
Initialized ret to 0 in DiskGetGeometry to prevent optimizer short circuit.

# Testing
- Flashed and works on REV 1

# Outstanding Changes

