### PR TITLE
Configurable block times for RM46 and CC1120 functions

### DIFF
--- a/obc/drivers/arducam/camera_reg.c
+++ b/obc/drivers/arducam/camera_reg.c
@@ -57,14 +57,14 @@ obc_error_code_t camReadByte(uint8_t *byte, camera_t cam) {
 
 obc_error_code_t camWriteSensorReg16_8(uint32_t regID, uint8_t regDat) {
   uint8_t reg_tx_data[3] = {(regID >> 8), (regID & 0x00FF), regDat};
-  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data);
+  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data, pdMS_TO_TICKS(100), portMAX_DELAY);
 }
 
 obc_error_code_t camReadSensorReg16_8(uint8_t regID, uint8_t *regDat) {
   // Todo: regID is byteswapped for some reason so 0x3138 needs to be input as 0x3831
   obc_error_code_t errCode;
-  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID));
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat));
+  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID, pdMS_TO_TICKS(100), portMAX_DELAY));
+  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat, pdMS_TO_TICKS(100), portMAX_DELAY));
   return errCode;
 }
 
@@ -85,7 +85,7 @@ obc_error_code_t tcaSelect(camera_t cam) {
   } else {
     tca = (1 << 1);
   }
-  return i2cSendTo(TCA_I2C_ADDR, 1, &tca);
+  return i2cSendTo(TCA_I2C_ADDR, 1, &tca, pdMS_TO_TICKS(100), portMAX_DELAY);
 }
 
 uint8_t getBit(uint8_t addr, uint8_t bit, camera_t cam) {

--- a/obc/drivers/arducam/camera_reg.c
+++ b/obc/drivers/arducam/camera_reg.c
@@ -14,6 +14,9 @@
 
 #define TCA_I2C_ADDR 0x70
 
+#define I2C_MUTEX_TIMEOUT portMAX_DELAY
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
+
 static cam_settings_t cam_config[] = {
     [PRIMARY] = {.spi_config = {.CS_HOLD = false, .WDEL = false, .DFSEL = CAM_SPI_DATA_FORMAT, .CSNR = SPI_CS_NONE},
                  .cs_num = CAM_CS_1},
@@ -57,14 +60,14 @@ obc_error_code_t camReadByte(uint8_t *byte, camera_t cam) {
 
 obc_error_code_t camWriteSensorReg16_8(uint32_t regID, uint8_t regDat) {
   uint8_t reg_tx_data[3] = {(regID >> 8), (regID & 0x00FF), regDat};
-  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data, portMAX_DELAY, pdMS_TO_TICKS(100));
+  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT);
 }
 
 obc_error_code_t camReadSensorReg16_8(uint8_t regID, uint8_t *regDat) {
   // Todo: regID is byteswapped for some reason so 0x3138 needs to be input as 0x3831
   obc_error_code_t errCode;
-  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID, portMAX_DELAY, pdMS_TO_TICKS(100)));
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat, portMAX_DELAY, pdMS_TO_TICKS(100)));
+  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
   return errCode;
 }
 
@@ -85,7 +88,7 @@ obc_error_code_t tcaSelect(camera_t cam) {
   } else {
     tca = (1 << 1);
   }
-  return i2cSendTo(TCA_I2C_ADDR, 1, &tca, portMAX_DELAY, pdMS_TO_TICKS(100));
+  return i2cSendTo(TCA_I2C_ADDR, 1, &tca, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT);
 }
 
 uint8_t getBit(uint8_t addr, uint8_t bit, camera_t cam) {

--- a/obc/drivers/arducam/camera_reg.c
+++ b/obc/drivers/arducam/camera_reg.c
@@ -57,14 +57,14 @@ obc_error_code_t camReadByte(uint8_t *byte, camera_t cam) {
 
 obc_error_code_t camWriteSensorReg16_8(uint32_t regID, uint8_t regDat) {
   uint8_t reg_tx_data[3] = {(regID >> 8), (regID & 0x00FF), regDat};
-  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data, pdMS_TO_TICKS(100), portMAX_DELAY);
+  return i2cSendTo(CAM_I2C_WR_ADDR, 3, reg_tx_data, portMAX_DELAY, pdMS_TO_TICKS(100));
 }
 
 obc_error_code_t camReadSensorReg16_8(uint8_t regID, uint8_t *regDat) {
   // Todo: regID is byteswapped for some reason so 0x3138 needs to be input as 0x3831
   obc_error_code_t errCode;
-  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID, pdMS_TO_TICKS(100), portMAX_DELAY));
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat, pdMS_TO_TICKS(100), portMAX_DELAY));
+  RETURN_IF_ERROR_CODE(i2cSendTo(0x3C, 2, &regID, portMAX_DELAY, pdMS_TO_TICKS(100)));
+  RETURN_IF_ERROR_CODE(i2cReceiveFrom(0x3C, 1, regDat, portMAX_DELAY, pdMS_TO_TICKS(100)));
   return errCode;
 }
 
@@ -85,7 +85,7 @@ obc_error_code_t tcaSelect(camera_t cam) {
   } else {
     tca = (1 << 1);
   }
-  return i2cSendTo(TCA_I2C_ADDR, 1, &tca, pdMS_TO_TICKS(100), portMAX_DELAY);
+  return i2cSendTo(TCA_I2C_ADDR, 1, &tca, portMAX_DELAY, pdMS_TO_TICKS(100));
 }
 
 uint8_t getBit(uint8_t addr, uint8_t bit, camera_t cam) {

--- a/obc/drivers/cc1120/cc1120_txrx.h
+++ b/obc/drivers/cc1120/cc1120_txrx.h
@@ -75,10 +75,10 @@ obc_error_code_t cc1120Init(void);
  *
  * @param data - An array of 8-bit data to transmit
  * @param len - The size of the provided array
- * @param txFifoTimeout - The amount of time to wait for the txFifoEmptySemaphore to become available
+ * @param txFifoEmptyTimeoutTicks - The amount of time to wait for the txFifoEmptySemaphore to become available
  * @return obc_error_code_t
  */
-obc_error_code_t cc1120Send(uint8_t *data, uint32_t len, TickType_t txFifoTimeout);
+obc_error_code_t cc1120Send(uint8_t *data, uint32_t len, TickType_t txFifoEmptyTimeoutTicks);
 
 /* RX functions */
 /**
@@ -91,18 +91,17 @@ obc_error_code_t cc1120GetBytesInRxFifo(uint8_t *numBytes);
 
 /**
  * @brief Switches the cc1120 to RX mode to continuously receive bytes and send them to the decode task
- * @param syncTimeout - The amount of time to wait for the syncReceivedSemaphore to become available
- * @param rxTimeout - The amount of time to wait for the rxSemaphore to become available
+ * @param syncWordTimeoutTicks - The amount of time to wait for the syncReceivedSemaphore to become available
  * @return obc_error_code_t
  */
-obc_error_code_t cc1120Receive(TickType_t syncTimeout, TickType_t rxTimeout);
+obc_error_code_t cc1120Receive(TickType_t syncWordTimeoutTicks);
 
 /**
  * @brief block until the tx fifo is empty without decrementing the semaphore
- * @param txFifoTimeout - The amount of time to wait for the txFifoEmptySemaphore to become available
+ *
  * @return obc_error_code_t - whether the tx fifo empty semaphore became available without timing out or not
  */
-obc_error_code_t txFifoEmptyCheckBlocking(TickType_t txFifoTimeout);
+obc_error_code_t txFifoEmptyCheckBlocking(void);
 
 /**
  * @brief callback function to be used in an ISR when the TX FIFO drops below (CC1120_TX_FIFO_SIZE -

--- a/obc/drivers/cc1120/cc1120_txrx.h
+++ b/obc/drivers/cc1120/cc1120_txrx.h
@@ -75,9 +75,10 @@ obc_error_code_t cc1120Init(void);
  *
  * @param data - An array of 8-bit data to transmit
  * @param len - The size of the provided array
+ * @param txFifoTimeout - The amount of time to wait for the txFifoEmptySemaphore to become available
  * @return obc_error_code_t
  */
-obc_error_code_t cc1120Send(uint8_t *data, uint32_t len);
+obc_error_code_t cc1120Send(uint8_t *data, uint32_t len, TickType_t txFifoTimeout);
 
 /* RX functions */
 /**
@@ -90,17 +91,18 @@ obc_error_code_t cc1120GetBytesInRxFifo(uint8_t *numBytes);
 
 /**
  * @brief Switches the cc1120 to RX mode to continuously receive bytes and send them to the decode task
- *
+ * @param syncTimeout - The amount of time to wait for the syncReceivedSemaphore to become available
+ * @param rxTimeout - The amount of time to wait for the rxSemaphore to become available
  * @return obc_error_code_t
  */
-obc_error_code_t cc1120Receive(void);
+obc_error_code_t cc1120Receive(TickType_t syncTimeout, TickType_t rxTimeout);
 
 /**
  * @brief block until the tx fifo is empty without decrementing the semaphore
- *
+ * @param txFifoTimeout - The amount of time to wait for the txFifoEmptySemaphore to become available
  * @return obc_error_code_t - whether the tx fifo empty semaphore became available without timing out or not
  */
-obc_error_code_t txFifoEmptyCheckBlocking(void);
+obc_error_code_t txFifoEmptyCheckBlocking(TickType_t txFifoTimeout);
 
 /**
  * @brief callback function to be used in an ISR when the TX FIFO drops below (CC1120_TX_FIFO_SIZE -

--- a/obc/drivers/ds3232/ds3232_mz.c
+++ b/obc/drivers/ds3232/ds3232_mz.c
@@ -50,6 +50,8 @@
 #define MAX_MONTH 12U
 #define MAX_YEAR 99U
 
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
+
 typedef enum {
   ENABLE_MATCH = 0U,
   DISABLE_MATCH = 1U,
@@ -148,7 +150,7 @@ obc_error_code_t getSecondsRTC(uint8_t *seconds) {
   if (seconds == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_SECONDS, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_SECONDS, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *seconds = twoDigitDecimalFromBCD(data);
 
@@ -160,7 +162,7 @@ obc_error_code_t getMinutesRTC(uint8_t *minutes) {
   if (minutes == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_MINUTES, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_MINUTES, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *minutes = twoDigitDecimalFromBCD(data);
 
@@ -173,7 +175,7 @@ obc_error_code_t getHourRTC(uint8_t *hours) {
   if (hours == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_HOURS, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_HOURS, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *hours = twoDigitDecimalFromBCD(data);
 
@@ -186,7 +188,7 @@ obc_error_code_t getDayRTC(uint8_t *days) {
   if (days == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_DAY, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_DAY, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *days = data;
 
@@ -199,7 +201,7 @@ obc_error_code_t getDateRTC(uint8_t *date) {
   if (date == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_DATE, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_DATE, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *date = twoDigitDecimalFromBCD(data);
 
@@ -212,7 +214,7 @@ obc_error_code_t getMonthRTC(uint8_t *month) {
   if (month == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_MONTH, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_MONTH, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *month = twoDigitDecimalFromBCD(data & 0x1F);
 
@@ -225,7 +227,7 @@ obc_error_code_t getYearRTC(uint8_t *year) {
   if (year == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_YEAR, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_YEAR, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *year = twoDigitDecimalFromBCD(data);
 
@@ -270,7 +272,7 @@ obc_error_code_t getControlRTC(rtc_control_t *control) {
   if (control == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_CONTROL, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_CONTROL, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   control->EOSC = (data >> 7) & 1;
   control->BBSQW = (data >> 6) & 1;
@@ -288,7 +290,7 @@ obc_error_code_t getStatusRTC(rtc_status_t *status) {
   if (status == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_STATUS, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_STATUS, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   status->OSF = (data >> 7) & 1;
   status->BB32KHZ = (data >> 6) & 1;
@@ -306,7 +308,7 @@ obc_error_code_t getAgingOffsetRTC(int8_t *agingOffset) {
   if (agingOffset == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t data;
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_AGING, &data, 1));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_AGING, &data, 1, I2C_TRANSFER_TIMEOUT));
 
   *agingOffset = (int8_t)data;
 
@@ -319,7 +321,7 @@ obc_error_code_t getTemperatureRTC(float *temperature) {
   if (temperature == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
   uint8_t dataBuff[2];
-  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_TEMP_MSB, dataBuff, 2));
+  RETURN_IF_ERROR_CODE(i2cReadReg(DS3232_I2C_ADDRESS, DS3232_REG_TEMP_MSB, dataBuff, 2, I2C_TRANSFER_TIMEOUT));
 
   int16_t val = ((int8_t)dataBuff[0] << 2) | (dataBuff[1] >> 6);
 

--- a/obc/drivers/lm75bd/lm75bd.c
+++ b/obc/drivers/lm75bd/lm75bd.c
@@ -9,6 +9,8 @@
 
 #define LM75BD_I2C_BASE_ADDR 0x9U
 
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
+
 STATIC_ASSERT_EQ(LM75BD_OBC_I2C_ADDR >> 3, LM75BD_I2C_BASE_ADDR);
 
 /* LM75BD Registers (p.8) */
@@ -60,7 +62,7 @@ obc_error_code_t readTempLM75BD(uint8_t devAddr, float *temp) {
 
   if (temp == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_TEMP, tempBuff, LM75BD_TEMP_BUFF_SIZE));
+  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_TEMP, tempBuff, LM75BD_TEMP_BUFF_SIZE, I2C_TRANSFER_TIMEOUT));
 
   /* Combine the 11 MSB into a 16-bit signed integer */
   int16_t value = ((int8_t)tempBuff[0] << 3) | (tempBuff[1] >> 5);
@@ -79,7 +81,8 @@ obc_error_code_t readConfigLM75BD(lm75bd_config_t *config) {
 
   if (config == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cReadReg(config->devAddr, LM75BD_REG_CONF, configBuff, LM75BD_CONF_BUFF_SIZE));
+  RETURN_IF_ERROR_CODE(
+      i2cReadReg(config->devAddr, LM75BD_REG_CONF, configBuff, LM75BD_CONF_BUFF_SIZE, I2C_TRANSFER_TIMEOUT));
 
   uint8_t osFaltQueueRegData = (configBuff[0] & LM75BD_OS_FAULT_QUEUE_MASK) >> 3;
   if (osFaltQueueRegData > 3) return OBC_ERR_CODE_I2C_FAILURE;
@@ -130,7 +133,7 @@ obc_error_code_t readThystLM75BD(uint8_t devAddr, float *hysteresisThresholdCels
 
   if (hysteresisThresholdCelsius == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_THYST, thystBuff, LM75BD_THYST_BUFF_SIZE));
+  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_THYST, thystBuff, LM75BD_THYST_BUFF_SIZE, I2C_TRANSFER_TIMEOUT));
 
   /* Combine the 9 MSB into a 16-bit signed integer */
   int16_t value = ((int8_t)thystBuff[0] << 1) | (thystBuff[1] >> 7);
@@ -165,7 +168,7 @@ obc_error_code_t readTosLM75BD(uint8_t devAddr, float *overTempThresholdCelsius)
 
   if (overTempThresholdCelsius == NULL) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_TOS, tosBuff, LM75BD_TOS_BUFF_SIZE));
+  RETURN_IF_ERROR_CODE(i2cReadReg(devAddr, LM75BD_REG_TOS, tosBuff, LM75BD_TOS_BUFF_SIZE, I2C_TRANSFER_TIMEOUT));
 
   /* Combine the 9 MSB into a 16-bit signed integer */
   int16_t value = ((int8_t)tosBuff[0] << 1) | (tosBuff[1] >> 7);

--- a/obc/drivers/max5360/max5360.c
+++ b/obc/drivers/max5360/max5360.c
@@ -14,6 +14,9 @@
   ((float)DAC_VREF_VALUE * 0b00111111 / \
    DAC_STEP_VALUE)  // the dac takes a 6 bit number for what to output so the max for that number is 0b00111111
 
+#define I2C_MUTEX_TIMEOUT portMAX_DELAY
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
+
 /**
  * @brief powers on the max5460 DAC and sets it to output a certain voltage
  *
@@ -31,7 +34,8 @@ obc_error_code_t max5360WriteVoltage(float analogVoltsOutput) {
   // round the value to the nearest integer before casting
   uint8_t dacCode = ((uint8_t)(analogVoltsOutput * DAC_STEP_VALUE / DAC_VREF_VALUE + 0.5)) << 2;
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode, portMAX_DELAY, pdMS_TO_TICKS(100)));
+  RETURN_IF_ERROR_CODE(
+      i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
   return OBC_ERR_CODE_SUCCESS;
 }
 
@@ -46,7 +50,7 @@ obc_error_code_t max5360PowerOff(void) {
   // Reading from the DAC will turn it off
   // See datasheet page 10
   RETURN_IF_ERROR_CODE(
-      i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf, portMAX_DELAY, pdMS_TO_TICKS(100)));
+      i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
   // DAC should output all ones
   if (dacRecvBuf != UINT8_MAX) {
     return OBC_ERR_CODE_MAX5360_SHUTDOWN_FAILURE;

--- a/obc/drivers/max5360/max5360.c
+++ b/obc/drivers/max5360/max5360.c
@@ -31,7 +31,7 @@ obc_error_code_t max5360WriteVoltage(float analogVoltsOutput) {
   // round the value to the nearest integer before casting
   uint8_t dacCode = ((uint8_t)(analogVoltsOutput * DAC_STEP_VALUE / DAC_VREF_VALUE + 0.5)) << 2;
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode, pdMS_TO_TICKS(100), portMAX_DELAY));
+  RETURN_IF_ERROR_CODE(i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode, portMAX_DELAY, pdMS_TO_TICKS(100)));
   return OBC_ERR_CODE_SUCCESS;
 }
 
@@ -46,7 +46,7 @@ obc_error_code_t max5360PowerOff(void) {
   // Reading from the DAC will turn it off
   // See datasheet page 10
   RETURN_IF_ERROR_CODE(
-      i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf, pdMS_TO_TICKS(100), portMAX_DELAY));
+      i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf, portMAX_DELAY, pdMS_TO_TICKS(100)));
   // DAC should output all ones
   if (dacRecvBuf != UINT8_MAX) {
     return OBC_ERR_CODE_MAX5360_SHUTDOWN_FAILURE;

--- a/obc/drivers/max5360/max5360.c
+++ b/obc/drivers/max5360/max5360.c
@@ -31,7 +31,7 @@ obc_error_code_t max5360WriteVoltage(float analogVoltsOutput) {
   // round the value to the nearest integer before casting
   uint8_t dacCode = ((uint8_t)(analogVoltsOutput * DAC_STEP_VALUE / DAC_VREF_VALUE + 0.5)) << 2;
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode));
+  RETURN_IF_ERROR_CODE(i2cSendTo(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacCode, pdMS_TO_TICKS(100), portMAX_DELAY));
   return OBC_ERR_CODE_SUCCESS;
 }
 
@@ -45,7 +45,8 @@ obc_error_code_t max5360PowerOff(void) {
   uint8_t dacRecvBuf;
   // Reading from the DAC will turn it off
   // See datasheet page 10
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf));
+  RETURN_IF_ERROR_CODE(
+      i2cReceiveFrom(DAC_ADDRESS, DAC_CODE_TRANSFER_BYTES, &dacRecvBuf, pdMS_TO_TICKS(100), portMAX_DELAY));
   // DAC should output all ones
   if (dacRecvBuf != UINT8_MAX) {
     return OBC_ERR_CODE_MAX5360_SHUTDOWN_FAILURE;

--- a/obc/drivers/rm46/obc_i2c_io.c
+++ b/obc/drivers/rm46/obc_i2c_io.c
@@ -115,16 +115,17 @@ obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, Tick
   return errCode;
 }
 
-obc_error_code_t i2cReadReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint16_t numBytes) {
+obc_error_code_t i2cReadReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint16_t numBytes,
+                            TickType_t transferTimeoutTicks) {
   obc_error_code_t errCode;
 
   ASSERT(i2cMutex != NULL);
 
   if (data == NULL || numBytes < 1) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, 1, &reg, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, 1, &reg, I2C_MUTEX_TIMEOUT, transferTimeoutTicks));
 
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(sAddr, numBytes, data, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cReceiveFrom(sAddr, numBytes, data, I2C_MUTEX_TIMEOUT, transferTimeoutTicks));
 
   return OBC_ERR_CODE_SUCCESS;
 }

--- a/obc/drivers/rm46/obc_i2c_io.c
+++ b/obc/drivers/rm46/obc_i2c_io.c
@@ -46,8 +46,8 @@ void initI2CMutex(void) {
   ASSERT(i2cTransferComplete != NULL);
 }
 
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
-                           TickType_t mutexTimeout) {
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
+                           TickType_t transferTimeout) {
   obc_error_code_t errCode;
 
   ASSERT(i2cMutex != NULL);
@@ -80,8 +80,8 @@ obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_
   return errCode;
 }
 
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
-                                TickType_t mutexTimeout) {
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
+                                TickType_t transferTimeout) {
   obc_error_code_t errCode;
 
   ASSERT(i2cMutex != NULL);
@@ -122,9 +122,9 @@ obc_error_code_t i2cReadReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint16_t 
 
   if (data == NULL || numBytes < 1) return OBC_ERR_CODE_INVALID_ARG;
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, 1, &reg, I2C_TRANSFER_TIMEOUT, I2C_MUTEX_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, 1, &reg, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
 
-  RETURN_IF_ERROR_CODE(i2cReceiveFrom(sAddr, numBytes, data, I2C_TRANSFER_TIMEOUT, I2C_MUTEX_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cReceiveFrom(sAddr, numBytes, data, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
 
   return OBC_ERR_CODE_SUCCESS;
 }
@@ -143,7 +143,7 @@ obc_error_code_t i2cWriteReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint8_t 
     dataBuf[i + 1] = data[i];
   }
 
-  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, numBytes + 1, dataBuf, I2C_TRANSFER_TIMEOUT, I2C_MUTEX_TIMEOUT));
+  RETURN_IF_ERROR_CODE(i2cSendTo(sAddr, numBytes + 1, dataBuf, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT));
   return OBC_ERR_CODE_SUCCESS;
 }
 

--- a/obc/drivers/rm46/obc_i2c_io.c
+++ b/obc/drivers/rm46/obc_i2c_io.c
@@ -46,15 +46,15 @@ void initI2CMutex(void) {
   ASSERT(i2cTransferComplete != NULL);
 }
 
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
-                           TickType_t transferTimeout) {
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeoutTicks,
+                           TickType_t transferTimeoutTicks) {
   obc_error_code_t errCode;
 
   ASSERT(i2cMutex != NULL);
 
   if (buf == NULL || size < 1) return OBC_ERR_CODE_INVALID_ARG;
 
-  if (xSemaphoreTake(i2cMutex, mutexTimeout) != pdTRUE) {
+  if (xSemaphoreTake(i2cMutex, mutexTimeoutTicks) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 
@@ -67,7 +67,7 @@ obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_
 
   i2cSend(I2C_REG, size, buf);
 
-  if (xSemaphoreTake(i2cTransferComplete, transferTimeout) != pdTRUE) {
+  if (xSemaphoreTake(i2cTransferComplete, transferTimeoutTicks) != pdTRUE) {
     errCode = OBC_ERR_CODE_I2C_TRANSFER_TIMEOUT;
     i2cSetStop(I2C_REG);
   } else {
@@ -80,15 +80,15 @@ obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_
   return errCode;
 }
 
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
-                                TickType_t transferTimeout) {
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeoutTicks,
+                                TickType_t transferTimeoutTicks) {
   obc_error_code_t errCode;
 
   ASSERT(i2cMutex != NULL);
 
   if (buf == NULL || size < 1) return OBC_ERR_CODE_INVALID_ARG;
 
-  if (xSemaphoreTake(i2cMutex, mutexTimeout) != pdTRUE) {
+  if (xSemaphoreTake(i2cMutex, mutexTimeoutTicks) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 
@@ -101,7 +101,7 @@ obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, Tick
 
   i2cReceive(I2C_REG, size, buf);
 
-  if (xSemaphoreTake(i2cTransferComplete, transferTimeout) != pdTRUE) {
+  if (xSemaphoreTake(i2cTransferComplete, transferTimeoutTicks) != pdTRUE) {
     errCode = OBC_ERR_CODE_I2C_TRANSFER_TIMEOUT;
     i2cSetStop(I2C_REG);
   } else {

--- a/obc/drivers/rm46/obc_i2c_io.h
+++ b/obc/drivers/rm46/obc_i2c_io.h
@@ -17,20 +17,26 @@ void initI2CMutex(void);
  * @param sAddr The slave address of the device to send to
  * @param size The number of bytes to send
  * @param buf The buffer to send
+ * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
+ * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf);
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
+                           TickType_t mutexTimeout);
 
 /**
  * @brief Receive a buffer of bytes from a device on the I2C bus
  * @param sAddr The slave address of the device to receive from
  * @param size The number of bytes to receive
  * @param buf The buffer to receive into
+ * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
+ * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf);
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
+                                TickType_t mutexTimeout);
 
 /**
  * @brief Read byte(s) from a device's register(s).

--- a/obc/drivers/rm46/obc_i2c_io.h
+++ b/obc/drivers/rm46/obc_i2c_io.h
@@ -44,10 +44,12 @@ obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, Tick
  * @param reg The register to read from
  * @param data The buffer to read into
  * @param numBytes The number of bytes to read
+ * @param transferTimeoutTicks The maximum time (in ticks) to wait for the transfer to complete
  * @note  You can read from consecutive registers by using numBytes > 1.
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t i2cReadReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint16_t numBytes);
+obc_error_code_t i2cReadReg(uint8_t sAddr, uint8_t reg, uint8_t *data, uint16_t numBytes,
+                            TickType_t transferTimeoutTicks);
 
 /**
  * @brief Write byte(s) to a device's register(s).

--- a/obc/drivers/rm46/obc_i2c_io.h
+++ b/obc/drivers/rm46/obc_i2c_io.h
@@ -17,26 +17,26 @@ void initI2CMutex(void);
  * @param sAddr The slave address of the device to send to
  * @param size The number of bytes to send
  * @param buf The buffer to send
- * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
- * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
+ * @param mutexTimeoutTicks The maximum time (in ticks) to wait for the i2c bus mutex to be acquired
+ * @param transferTimeoutTicks The maximum time (in ticks) to wait for the transfer to complete
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
-                           TickType_t transferTimeout);
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeoutTicks,
+                           TickType_t transferTimeoutTicks);
 
 /**
  * @brief Receive a buffer of bytes from a device on the I2C bus
  * @param sAddr The slave address of the device to receive from
  * @param size The number of bytes to receive
  * @param buf The buffer to receive into
- * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
- * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
+ * @param mutexTimeoutTicks The maximum time (in ticks) to wait for the i2c bus mutex to be acquired
+ * @param transferTimeoutTicks The maximum time (in ticks) to wait for the transfer to complete
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
-                                TickType_t mutexTimeout);
+obc_error_code_t i2cReceiveFrom(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeoutTicks,
+                                TickType_t mutexTimeoutTicks);
 
 /**
  * @brief Read byte(s) from a device's register(s).

--- a/obc/drivers/rm46/obc_i2c_io.h
+++ b/obc/drivers/rm46/obc_i2c_io.h
@@ -17,21 +17,21 @@ void initI2CMutex(void);
  * @param sAddr The slave address of the device to send to
  * @param size The number of bytes to send
  * @param buf The buffer to send
- * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
  * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
+ * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */
-obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t transferTimeout,
-                           TickType_t mutexTimeout);
+obc_error_code_t i2cSendTo(uint8_t sAddr, uint16_t size, uint8_t *buf, TickType_t mutexTimeout,
+                           TickType_t transferTimeout);
 
 /**
  * @brief Receive a buffer of bytes from a device on the I2C bus
  * @param sAddr The slave address of the device to receive from
  * @param size The number of bytes to receive
  * @param buf The buffer to receive into
- * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
  * @param mutexTimeout The maximum time (in ticks) to wait for the mutex to be acquired
+ * @param transferTimeout The maximum time (in ticks) to wait for the transfer to complete
  * @return OBC_ERR_CODE_SUCCESS if the bytes were sent, OBC_ERR_CODE_MUTEX_TIMEOUT if the mutex timed out,
  * OBC_ERR_CODE_INVALID_ARG if the buffer is NULL or the size is 0
  */

--- a/obc/drivers/rm46/obc_sci_io.c
+++ b/obc/drivers/rm46/obc_sci_io.c
@@ -61,13 +61,13 @@ void initSciMutex(void) {
   sciSetBaudrate(UART_READ_REG, OBC_UART_BAUD_RATE);
 }
 
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length) {
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartTimeout) {
   if (text == NULL || length == 0) return OBC_ERR_CODE_INVALID_ARG;
 
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex);
 
-  if (xSemaphoreTake(mutex, UART_MUTEX_BLOCK_TIME) == pdTRUE) {
+  if (xSemaphoreTake(mutex, uartTimeout) == pdTRUE) {
     obc_error_code_t err = sciSendString(text, length);
     xSemaphoreGive(mutex);
     return err;
@@ -102,7 +102,7 @@ obc_error_code_t sciPrintf(const char *s, ...) {
   // n == MAX_PRINTF_SIZE invalid because null character isn't included in count
   if ((uint32_t)n >= MAX_PRINTF_SIZE) return OBC_ERR_CODE_INVALID_ARG;
 
-  return sciPrintText((unsigned char *)buf, MAX_PRINTF_SIZE);
+  return sciPrintText((unsigned char *)buf, MAX_PRINTF_SIZE, UART_MUTEX_BLOCK_TIME);
 }
 
 void uartAssertFailed(char *file, int line, char *expr) {
@@ -131,7 +131,7 @@ obc_error_code_t sciReadByte(unsigned char *character) {
 }
 */
 
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, size_t blockTimeTicks) {
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout, size_t blockTimeTicks) {
   obc_error_code_t errCode;
 
   SemaphoreHandle_t mutex = (UART_READ_REG == sciREG) ? sciMutex : sciLinMutex;
@@ -141,7 +141,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, size_t blockTimeTic
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, UART_MUTEX_BLOCK_TIME) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartTimeout) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 
@@ -165,7 +165,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, size_t blockTimeTic
   return errCode;
 }
 
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes) {
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout) {
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex != NULL);
 
@@ -173,7 +173,7 @@ obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes) {
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, UART_MUTEX_BLOCK_TIME) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartTimeout) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 

--- a/obc/drivers/rm46/obc_sci_io.c
+++ b/obc/drivers/rm46/obc_sci_io.c
@@ -61,13 +61,13 @@ void initSciMutex(void) {
   sciSetBaudrate(UART_READ_REG, OBC_UART_BAUD_RATE);
 }
 
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartTimeout) {
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeout) {
   if (text == NULL || length == 0) return OBC_ERR_CODE_INVALID_ARG;
 
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex);
 
-  if (xSemaphoreTake(mutex, uartTimeout) == pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeout) == pdTRUE) {
     obc_error_code_t err = sciSendString(text, length);
     xSemaphoreGive(mutex);
     return err;
@@ -131,7 +131,7 @@ obc_error_code_t sciReadByte(unsigned char *character) {
 }
 */
 
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout, size_t blockTimeTicks) {
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout, size_t blockTimeTicks) {
   obc_error_code_t errCode;
 
   SemaphoreHandle_t mutex = (UART_READ_REG == sciREG) ? sciMutex : sciLinMutex;
@@ -141,7 +141,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTime
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, uartTimeout) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeout) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 
@@ -165,7 +165,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTime
   return errCode;
 }
 
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout) {
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout) {
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex != NULL);
 
@@ -173,7 +173,7 @@ obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartTime
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, uartTimeout) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeout) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 

--- a/obc/drivers/rm46/obc_sci_io.c
+++ b/obc/drivers/rm46/obc_sci_io.c
@@ -61,13 +61,13 @@ void initSciMutex(void) {
   sciSetBaudrate(UART_READ_REG, OBC_UART_BAUD_RATE);
 }
 
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeout) {
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeoutTicks) {
   if (text == NULL || length == 0) return OBC_ERR_CODE_INVALID_ARG;
 
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex);
 
-  if (xSemaphoreTake(mutex, uartMutexTimeout) == pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeoutTicks) == pdTRUE) {
     obc_error_code_t err = sciSendString(text, length);
     xSemaphoreGive(mutex);
     return err;
@@ -131,7 +131,7 @@ obc_error_code_t sciReadByte(unsigned char *character) {
 }
 */
 
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout, size_t blockTimeTicks) {
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeoutTicks, size_t blockTimeTicks) {
   obc_error_code_t errCode;
 
   SemaphoreHandle_t mutex = (UART_READ_REG == sciREG) ? sciMutex : sciLinMutex;
@@ -141,7 +141,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMute
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, uartMutexTimeout) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeoutTicks) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 
@@ -165,7 +165,7 @@ obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMute
   return errCode;
 }
 
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout) {
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeoutTicks) {
   SemaphoreHandle_t mutex = (UART_PRINT_REG == sciREG) ? sciMutex : sciLinMutex;
   configASSERT(mutex != NULL);
 
@@ -173,7 +173,7 @@ obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMute
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
-  if (xSemaphoreTake(mutex, uartMutexTimeout) != pdTRUE) {
+  if (xSemaphoreTake(mutex, uartMutexTimeoutTicks) != pdTRUE) {
     return OBC_ERR_CODE_MUTEX_TIMEOUT;
   }
 

--- a/obc/drivers/rm46/obc_sci_io.h
+++ b/obc/drivers/rm46/obc_sci_io.h
@@ -19,9 +19,10 @@ void initSciMutex(void);
  *
  * @param text The text to send.
  * @param length The length of the text to send.
+ * @param uartTimeout The number of ticks to wait for the mutex to become available.
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length);
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartTimeout);
 
 /**
  * @brief Printf via UART_PRINT_REG.
@@ -45,19 +46,21 @@ obc_error_code_t sciReadByte(unsigned char *character);
  *
  * @param numBytes Number of bytes to read
  * @param buf Buffer to store the bytes read
+ * @param uartTimeout Number of ticks to wait for the mutex to become available
  * @param blockTimeTicks Number of ticks to wait for async transfer to complete
  * @return obc_error_code_t OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, size_t blockTimeTicks);
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout, size_t blockTimeTicks);
 
 /**
  * @brief Send raw bytes to UART_PRINT_REG (blocking).
  *
  * @param buf Buffer to send
  * @param numBytes Number of bytes to send
+ * @param uartTimeout Number of ticks to wait for the mutex to become available
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes);
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout);
 
 /**
  * @brief Read a string from UART_READ_REG by polling and store it in the text buffer.

--- a/obc/drivers/rm46/obc_sci_io.h
+++ b/obc/drivers/rm46/obc_sci_io.h
@@ -19,10 +19,10 @@ void initSciMutex(void);
  *
  * @param text The text to send.
  * @param length The length of the text to send.
- * @param uartTimeout The number of ticks to wait for the mutex to become available.
+ * @param uartMutexTimeout The number of ticks to wait for the mutex to become available.
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartTimeout);
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeout);
 
 /**
  * @brief Printf via UART_PRINT_REG.
@@ -46,21 +46,21 @@ obc_error_code_t sciReadByte(unsigned char *character);
  *
  * @param numBytes Number of bytes to read
  * @param buf Buffer to store the bytes read
- * @param uartTimeout Number of ticks to wait for the mutex to become available
+ * @param uartMutexTimeout Number of ticks to wait for the mutex to become available
  * @param blockTimeTicks Number of ticks to wait for async transfer to complete
  * @return obc_error_code_t OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout, size_t blockTimeTicks);
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout, size_t blockTimeTicks);
 
 /**
  * @brief Send raw bytes to UART_PRINT_REG (blocking).
  *
  * @param buf Buffer to send
  * @param numBytes Number of bytes to send
- * @param uartTimeout Number of ticks to wait for the mutex to become available
+ * @param uartMutexTimeout Number of ticks to wait for the mutex to become available
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartTimeout);
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout);
 
 /**
  * @brief Read a string from UART_READ_REG by polling and store it in the text buffer.

--- a/obc/drivers/rm46/obc_sci_io.h
+++ b/obc/drivers/rm46/obc_sci_io.h
@@ -19,10 +19,10 @@ void initSciMutex(void);
  *
  * @param text The text to send.
  * @param length The length of the text to send.
- * @param uartMutexTimeout The number of ticks to wait for the mutex to become available.
+ * @param uartMutexTimeoutTicks The number of ticks to wait for the mutex to become available.
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeout);
+obc_error_code_t sciPrintText(unsigned char *text, uint32_t length, TickType_t uartMutexTimeoutTicks);
 
 /**
  * @brief Printf via UART_PRINT_REG.
@@ -46,21 +46,21 @@ obc_error_code_t sciReadByte(unsigned char *character);
  *
  * @param numBytes Number of bytes to read
  * @param buf Buffer to store the bytes read
- * @param uartMutexTimeout Number of ticks to wait for the mutex to become available
+ * @param uartMutexTimeoutTicks Number of ticks to wait for the mutex to become available
  * @param blockTimeTicks Number of ticks to wait for async transfer to complete
  * @return obc_error_code_t OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout, size_t blockTimeTicks);
+obc_error_code_t sciReadBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeoutTicks, size_t blockTimeTicks);
 
 /**
  * @brief Send raw bytes to UART_PRINT_REG (blocking).
  *
  * @param buf Buffer to send
  * @param numBytes Number of bytes to send
- * @param uartMutexTimeout Number of ticks to wait for the mutex to become available
+ * @param uartMutexTimeoutTicks Number of ticks to wait for the mutex to become available
  * @return OBC_ERR_CODE_SUCCESS on success, else an error code
  */
-obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeout);
+obc_error_code_t sciSendBytes(uint8_t *buf, size_t numBytes, TickType_t uartMutexTimeoutTicks);
 
 /**
  * @brief Read a string from UART_READ_REG by polling and store it in the text buffer.

--- a/obc/examples/dma_spi_demo/main.c
+++ b/obc/examples/dma_spi_demo/main.c
@@ -26,6 +26,8 @@
 /* example data Pattern configuration */
 #define D_SIZE 127
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 void task(void *pvParameters);
 
 static StackType_t stack[1024];
@@ -82,9 +84,9 @@ void task(void *pvParameters) {
 
       for (uint8_t i = 0; i < D_SIZE; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
 
   for (uint8_t i = 0; i < 50; ++i) {
     TX_DATA[i] = 0xff;
@@ -98,9 +100,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 50; ++i) {
     sprintf(str, "%u ", RX_DATA_SECOND[i + 1]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
 
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x55;
@@ -112,9 +114,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x33;
   }
@@ -125,9 +127,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x22;
   }
@@ -138,9 +140,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x11;
   }
@@ -151,9 +153,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x09;
   }
@@ -164,9 +166,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 5; ++i) {
     TX_DATA[i] = 0x08;
   }
@@ -177,9 +179,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 5; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   for (uint8_t i = 0; i < 3; ++i) {
     TX_DATA[i] = 0x07;
   }
@@ -190,9 +192,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 3; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
+    sciPrintText((unsigned char *)str, 5, UART_MUTEX_BLOCK_TIME);
   }
-  sciPrintText(spaceStr, 20, portMAX_DELAY);
+  sciPrintText(spaceStr, 20, UART_MUTEX_BLOCK_TIME);
   while (1)
     ;
 }

--- a/obc/examples/dma_spi_demo/main.c
+++ b/obc/examples/dma_spi_demo/main.c
@@ -82,9 +82,9 @@ void task(void *pvParameters) {
 
       for (uint8_t i = 0; i < D_SIZE; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
 
   for (uint8_t i = 0; i < 50; ++i) {
     TX_DATA[i] = 0xff;
@@ -98,9 +98,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 50; ++i) {
     sprintf(str, "%u ", RX_DATA_SECOND[i + 1]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
 
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x55;
@@ -112,9 +112,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x33;
   }
@@ -125,9 +125,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x22;
   }
@@ -138,9 +138,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x11;
   }
@@ -151,9 +151,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 10; ++i) {
     TX_DATA[i] = 0x09;
   }
@@ -164,9 +164,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 10; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 5; ++i) {
     TX_DATA[i] = 0x08;
   }
@@ -177,9 +177,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 5; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   for (uint8_t i = 0; i < 3; ++i) {
     TX_DATA[i] = 0x07;
   }
@@ -190,9 +190,9 @@ void task(void *pvParameters) {
 
   for (uint8_t i = 0; i < 3; ++i) {
     sprintf(str, "%u ", RX_DATA[i]);
-    sciPrintText((unsigned char *)str, 5);
+    sciPrintText((unsigned char *)str, 5, portMAX_DELAY);
   }
-  sciPrintText(spaceStr, 20);
+  sciPrintText(spaceStr, 20, portMAX_DELAY);
   while (1)
     ;
 }

--- a/obc/examples/test_app_fram_spi/main.c
+++ b/obc/examples/test_app_fram_spi/main.c
@@ -29,7 +29,7 @@ int main(void) {
   snprintf(msg, 50, "ID:%X %X %X %X %X %X %X %X %X\r\n", chipID[0], chipID[1], chipID[2], chipID[3], chipID[4],
            chipID[5], chipID[6], chipID[7], chipID[8]);
   // Note: This will send through the USB port on the LaunchPad
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   // Toggle the LED.
   gioToggleBit(gioPORTB, 1);
@@ -39,7 +39,7 @@ int main(void) {
   uint32_t addr = 0x31415;
   uint8_t byteData = 0xAB;
   snprintf(msg, 50, "Writting %X to %lX\r\n", byteData, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
   framWrite(addr, &byteData, 1);
 
   // Read 1 byte from 0x31415
@@ -47,12 +47,12 @@ int main(void) {
   byteData = 0;
   framRead(addr, &byteData, 1);
   snprintf(msg, 50, "Read %X from %lX\r\n", byteData, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   // Multipe Bytes
   unsigned char hello_world[12] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
   snprintf(msg, 50, "Writting %s to %lX\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
   // Write Hello World to 0x12345
   addr = 0x12345;
   framWrite(addr, hello_world, sizeof(hello_world));
@@ -61,36 +61,36 @@ int main(void) {
   memset(hello_world, 0, sizeof(hello_world));
   framRead(addr, hello_world, sizeof(hello_world));
   snprintf(msg, 50, "Read %s from %lX\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   // Read Status Register
   framReadStatusReg(&byteData);
   snprintf(msg, 50, "Status Register: %X\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   uint8_t oldStatusReg = byteData;
   byteData = 0b00001100;
   snprintf(msg, 50, "Writting %X to Status Register\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
   framWriteStatusReg(byteData);
 
   // Read Status Register
   framReadStatusReg(&byteData);
   snprintf(msg, 50, "Status Register: %X, Expected: 4C\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   // Reset Status Reg
   framWriteStatusReg(oldStatusReg);
 
   // Sleep
-  sciPrintText((unsigned char *)"Going to sleep\r\n", strlen("Going to sleep\r\n"));
+  sciPrintText((unsigned char *)"Going to sleep\r\n", strlen("Going to sleep\r\n"), portMAX_DELAY);
   framSleep();
   framWakeUp();
   // Read Hello World from 0x1234
   memset(hello_world, 0, sizeof(hello_world));
   framRead(addr, hello_world, sizeof(hello_world));
   snprintf(msg, 50, "Read %s from %lX after wakeup\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg));
+  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
 
   return 0;
 }

--- a/obc/examples/test_app_fram_spi/main.c
+++ b/obc/examples/test_app_fram_spi/main.c
@@ -11,6 +11,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 int main(void) {
   // Initialize hardware.
 
@@ -29,7 +31,7 @@ int main(void) {
   snprintf(msg, 50, "ID:%X %X %X %X %X %X %X %X %X\r\n", chipID[0], chipID[1], chipID[2], chipID[3], chipID[4],
            chipID[5], chipID[6], chipID[7], chipID[8]);
   // Note: This will send through the USB port on the LaunchPad
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   // Toggle the LED.
   gioToggleBit(gioPORTB, 1);
@@ -39,7 +41,7 @@ int main(void) {
   uint32_t addr = 0x31415;
   uint8_t byteData = 0xAB;
   snprintf(msg, 50, "Writting %X to %lX\r\n", byteData, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
   framWrite(addr, &byteData, 1);
 
   // Read 1 byte from 0x31415
@@ -47,12 +49,12 @@ int main(void) {
   byteData = 0;
   framRead(addr, &byteData, 1);
   snprintf(msg, 50, "Read %X from %lX\r\n", byteData, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   // Multipe Bytes
   unsigned char hello_world[12] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
   snprintf(msg, 50, "Writting %s to %lX\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
   // Write Hello World to 0x12345
   addr = 0x12345;
   framWrite(addr, hello_world, sizeof(hello_world));
@@ -61,36 +63,36 @@ int main(void) {
   memset(hello_world, 0, sizeof(hello_world));
   framRead(addr, hello_world, sizeof(hello_world));
   snprintf(msg, 50, "Read %s from %lX\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   // Read Status Register
   framReadStatusReg(&byteData);
   snprintf(msg, 50, "Status Register: %X\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   uint8_t oldStatusReg = byteData;
   byteData = 0b00001100;
   snprintf(msg, 50, "Writting %X to Status Register\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
   framWriteStatusReg(byteData);
 
   // Read Status Register
   framReadStatusReg(&byteData);
   snprintf(msg, 50, "Status Register: %X, Expected: 4C\r\n", byteData);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   // Reset Status Reg
   framWriteStatusReg(oldStatusReg);
 
   // Sleep
-  sciPrintText((unsigned char *)"Going to sleep\r\n", strlen("Going to sleep\r\n"), portMAX_DELAY);
+  sciPrintText((unsigned char *)"Going to sleep\r\n", strlen("Going to sleep\r\n"), UART_MUTEX_BLOCK_TIME);
   framSleep();
   framWakeUp();
   // Read Hello World from 0x1234
   memset(hello_world, 0, sizeof(hello_world));
   framRead(addr, hello_world, sizeof(hello_world));
   snprintf(msg, 50, "Read %s from %lX after wakeup\r\n", hello_world, addr);
-  sciPrintText((unsigned char *)msg, strlen(msg), portMAX_DELAY);
+  sciPrintText((unsigned char *)msg, strlen(msg), UART_MUTEX_BLOCK_TIME);
 
   return 0;
 }

--- a/obc/examples/test_app_mpu6050/source/mpu6050.c
+++ b/obc/examples/test_app_mpu6050/source/mpu6050.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
 
 void wakeupMPU6050(void) {
   uint8_t data = 0x00;
@@ -16,7 +17,7 @@ void wakeupMPU6050(void) {
 
 uint8_t readAccelDataMPU6050(double *accX, double *accY, double *accZ) {
   uint8_t data[6];
-  if (i2cReadReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_ACCEL_XOUT_H, data, 6) == 0) {
+  if (i2cReadReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_ACCEL_XOUT_H, data, 6, I2C_TRANSFER_TIMEOUT) == 0) {
     sciPrintText((unsigned char *)"Failed to read acceleration data\r\n", 35, UART_MUTEX_BLOCK_TIME);
     return 0;
   }

--- a/obc/examples/test_app_mpu6050/source/mpu6050.c
+++ b/obc/examples/test_app_mpu6050/source/mpu6050.c
@@ -7,15 +7,15 @@
 
 void wakeupMPU6050(void) {
   uint8_t data = 0x00;
-  sciPrintText((unsigned char *)"Trying to wake up MPU6050\r\n", 28);
+  sciPrintText((unsigned char *)"Trying to wake up MPU6050\r\n", 28, portMAX_DELAY);
   i2cWriteReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_PWR_MGMT_1, &data, 1);
-  sciPrintText((unsigned char *)"MPU6050 Woken Up\r\n", 19);
+  sciPrintText((unsigned char *)"MPU6050 Woken Up\r\n", 19, portMAX_DELAY);
 }
 
 uint8_t readAccelDataMPU6050(double *accX, double *accY, double *accZ) {
   uint8_t data[6];
   if (i2cReadReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_ACCEL_XOUT_H, data, 6) == 0) {
-    sciPrintText((unsigned char *)"Failed to read acceleration data\r\n", 35);
+    sciPrintText((unsigned char *)"Failed to read acceleration data\r\n", 35, portMAX_DELAY);
     return 0;
   }
 
@@ -25,7 +25,7 @@ uint8_t readAccelDataMPU6050(double *accX, double *accY, double *accZ) {
 
   char buf[31] = {};
   sprintf(buf, "X: %0.02f Y: %0.02f Z: %0.02f\r\n", *accX, *accY, *accZ);
-  sciPrintText((unsigned char *)buf, sizeof(buf));
+  sciPrintText((unsigned char *)buf, sizeof(buf), portMAX_DELAY);
 
   return 1;
 }

--- a/obc/examples/test_app_mpu6050/source/mpu6050.c
+++ b/obc/examples/test_app_mpu6050/source/mpu6050.c
@@ -5,17 +5,19 @@
 #include <sci.h>
 #include <stdio.h>
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 void wakeupMPU6050(void) {
   uint8_t data = 0x00;
-  sciPrintText((unsigned char *)"Trying to wake up MPU6050\r\n", 28, portMAX_DELAY);
+  sciPrintText((unsigned char *)"Trying to wake up MPU6050\r\n", 28, UART_MUTEX_BLOCK_TIME);
   i2cWriteReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_PWR_MGMT_1, &data, 1);
-  sciPrintText((unsigned char *)"MPU6050 Woken Up\r\n", 19, portMAX_DELAY);
+  sciPrintText((unsigned char *)"MPU6050 Woken Up\r\n", 19, UART_MUTEX_BLOCK_TIME);
 }
 
 uint8_t readAccelDataMPU6050(double *accX, double *accY, double *accZ) {
   uint8_t data[6];
   if (i2cReadReg(MPU6050_DEFAULT_ADDRESS, MPU6050_REG_ACCEL_XOUT_H, data, 6) == 0) {
-    sciPrintText((unsigned char *)"Failed to read acceleration data\r\n", 35, portMAX_DELAY);
+    sciPrintText((unsigned char *)"Failed to read acceleration data\r\n", 35, UART_MUTEX_BLOCK_TIME);
     return 0;
   }
 
@@ -25,7 +27,7 @@ uint8_t readAccelDataMPU6050(double *accX, double *accY, double *accZ) {
 
   char buf[31] = {};
   sprintf(buf, "X: %0.02f Y: %0.02f Z: %0.02f\r\n", *accX, *accY, *accZ);
-  sciPrintText((unsigned char *)buf, sizeof(buf), portMAX_DELAY);
+  sciPrintText((unsigned char *)buf, sizeof(buf), UART_MUTEX_BLOCK_TIME);
 
   return 1;
 }

--- a/obc/examples/test_app_reliance_edge_sd/main.c
+++ b/obc/examples/test_app_reliance_edge_sd/main.c
@@ -107,7 +107,7 @@ void vTask1(void *pvParameters) {
   sciPrintf("Successfully read from %s\r\n", fname);
 
   sciPrintf("Text read from %s: \r\n", fname);
-  sciPrintText(readBuf, ret);
+  sciPrintText(readBuf, ret, portMAX_DELAY);
 
   ret = red_close(file);
   if (ret < 0) {

--- a/obc/examples/test_app_reliance_edge_sd/main.c
+++ b/obc/examples/test_app_reliance_edge_sd/main.c
@@ -11,6 +11,8 @@
 #include <redposix.h>
 #include <string.h>
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];
 
@@ -107,7 +109,7 @@ void vTask1(void *pvParameters) {
   sciPrintf("Successfully read from %s\r\n", fname);
 
   sciPrintf("Text read from %s: \r\n", fname);
-  sciPrintText(readBuf, ret, portMAX_DELAY);
+  sciPrintText(readBuf, ret, UART_MUTEX_BLOCK_TIME);
 
   ret = red_close(file);
   if (ret < 0) {

--- a/obc/examples/test_app_uart_rx/main.c
+++ b/obc/examples/test_app_uart_rx/main.c
@@ -24,7 +24,7 @@ int main(void) {
       continue;
     }
 
-    sciPrintText(buffer, NUM_CHARS_TO_READ);
+    sciPrintText(buffer, NUM_CHARS_TO_READ, portMAX_DELAY);
     sciPrintf("\r\n");
 
     // Toggle the LED.

--- a/obc/examples/test_app_uart_rx/main.c
+++ b/obc/examples/test_app_uart_rx/main.c
@@ -6,6 +6,8 @@
 
 #define NUM_CHARS_TO_READ 20U
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 int main(void) {
   // Initialize hardware.
   gioInit();
@@ -24,7 +26,7 @@ int main(void) {
       continue;
     }
 
-    sciPrintText(buffer, NUM_CHARS_TO_READ, portMAX_DELAY);
+    sciPrintText(buffer, NUM_CHARS_TO_READ, UART_MUTEX_BLOCK_TIME);
     sciPrintf("\r\n");
 
     // Toggle the LED.

--- a/obc/examples/test_app_uart_tx/main.c
+++ b/obc/examples/test_app_uart_tx/main.c
@@ -3,6 +3,8 @@
 #include <gio.h>
 #include <sci.h>
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 int main(void) {
   // Initialize hardware.
   gioInit();
@@ -13,7 +15,7 @@ int main(void) {
 
   while (1) {
     // Send a string of text via SCI
-    sciPrintText((unsigned char *)"Hello from SCI!\r\n", 20, portMAX_DELAY);
+    sciPrintText((unsigned char *)"Hello from SCI!\r\n", 20, UART_MUTEX_BLOCK_TIME);
 
     // Test sciPrintf
     sciPrintf("Testing sciPrintf: %d %d %s\r\n", 0, 1, "Hello");

--- a/obc/examples/test_app_uart_tx/main.c
+++ b/obc/examples/test_app_uart_tx/main.c
@@ -13,7 +13,7 @@ int main(void) {
 
   while (1) {
     // Send a string of text via SCI
-    sciPrintText((unsigned char *)"Hello from SCI!\r\n", 20);
+    sciPrintText((unsigned char *)"Hello from SCI!\r\n", 20, portMAX_DELAY);
 
     // Test sciPrintf
     sciPrintf("Testing sciPrintf: %d %d %s\r\n", 0, 1, "Hello");

--- a/obc/modules/comms_link_mgr/comms_manager.c
+++ b/obc/modules/comms_link_mgr/comms_manager.c
@@ -49,9 +49,9 @@ static uint8_t commsQueueStack[COMMS_MANAGER_QUEUE_LENGTH * COMMS_MANAGER_QUEUE_
 #define CC1120_TRANSMIT_QUEUE_RX_WAIT_PERIOD portMAX_DELAY
 #define CC1120_TRANSMIT_QUEUE_TX_WAIT_PERIOD portMAX_DELAY
 #define CC1120_SYNC_EVENT_SEMAPHORE_TIMEOUT pdMS_TO_TICKS(30000)
-#define CC1120_TX_SEMAPHORE_TIMEOUT pdMS_TO_TICKS(5000)
+#define CC1120_TX_FIFO_EMPTY_SEMAPHORE_TIMEOUT pdMS_TO_TICKS(5000)
 
-#define RM46_UART_MUTEX_BLOCK_TIME portMAX_DELAY
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 
 static QueueHandle_t cc1120TransmitQueueHandle = NULL;
 static StaticQueue_t cc1120TransmitQueue;
@@ -143,10 +143,10 @@ static void vCommsManagerTask(void *pvParameters) {
           if (transmitEvent.eventID == DOWNLINK_PACKET) {
 #if COMMS_PHY == COMMS_PHY_UART
             LOG_IF_ERROR_CODE(sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length,
-                                           RM46_UART_MUTEX_BLOCK_TIME));
+                                           UART_MUTEX_BLOCK_TIME));
 #else
             LOG_IF_ERROR_CODE(cc1120Send((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length,
-                                         CC1120_TX_SEMAPHORE_TIMEOUT));
+                                         CC1120_TX_FIFO_EMPTY_SEMAPHORE_TIMEOUT));
 #endif
           } else if (transmitEvent.eventID == END_DOWNLINK) {
             break;

--- a/obc/modules/comms_link_mgr/comms_manager.c
+++ b/obc/modules/comms_link_mgr/comms_manager.c
@@ -140,7 +140,8 @@ static void vCommsManagerTask(void *pvParameters) {
 #if COMMS_PHY == COMMS_PHY_UART
             LOG_IF_ERROR_CODE(sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length));
 #else
-            LOG_IF_ERROR_CODE(cc1120Send((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length));
+            LOG_IF_ERROR_CODE(
+                cc1120Send((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, pdMS_TO_TICKS(5000)));
 #endif
           } else if (transmitEvent.eventID == END_DOWNLINK) {
             break;
@@ -177,7 +178,7 @@ static void vCommsManagerTask(void *pvParameters) {
 #endif
 #else
         // switch cc1120 to receive mode and start receiving all the bytes for one continuous transmission
-        LOG_IF_ERROR_CODE(cc1120Receive());
+        LOG_IF_ERROR_CODE(cc1120Receive(pdMS_TO_TICKS(30000), pdMS_TO_TICKS(100)));
         LOG_IF_ERROR_CODE(cc1120StrobeSpi(CC1120_STROBE_SFSTXON));
 #endif
         break;

--- a/obc/modules/comms_link_mgr/comms_manager.c
+++ b/obc/modules/comms_link_mgr/comms_manager.c
@@ -138,7 +138,8 @@ static void vCommsManagerTask(void *pvParameters) {
           }
           if (transmitEvent.eventID == DOWNLINK_PACKET) {
 #if COMMS_PHY == COMMS_PHY_UART
-            LOG_IF_ERROR_CODE(sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, portMAX_DELAY));
+            LOG_IF_ERROR_CODE(
+                sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, portMAX_DELAY));
 #else
             LOG_IF_ERROR_CODE(
                 cc1120Send((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, pdMS_TO_TICKS(5000)));

--- a/obc/modules/comms_link_mgr/comms_manager.c
+++ b/obc/modules/comms_link_mgr/comms_manager.c
@@ -138,7 +138,7 @@ static void vCommsManagerTask(void *pvParameters) {
           }
           if (transmitEvent.eventID == DOWNLINK_PACKET) {
 #if COMMS_PHY == COMMS_PHY_UART
-            LOG_IF_ERROR_CODE(sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length));
+            LOG_IF_ERROR_CODE(sciSendBytes((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, portMAX_DELAY));
 #else
             LOG_IF_ERROR_CODE(
                 cc1120Send((uint8_t *)transmitEvent.ax25Pkt.data, transmitEvent.ax25Pkt.length, pdMS_TO_TICKS(5000)));
@@ -155,7 +155,7 @@ static void vCommsManagerTask(void *pvParameters) {
         uint8_t rxByte;
 
         // Read first byte
-        LOG_IF_ERROR_CODE(sciReadBytes(&rxByte, 1, pdMS_TO_TICKS(1000)));
+        LOG_IF_ERROR_CODE(sciReadBytes(&rxByte, 1, portMAX_DELAY, pdMS_TO_TICKS(1000)));
 
         if (errCode == OBC_ERR_CODE_SUCCESS) {
           LOG_IF_ERROR_CODE(sendToDecodeDataQueue(&rxByte));
@@ -164,7 +164,7 @@ static void vCommsManagerTask(void *pvParameters) {
         if (errCode == OBC_ERR_CODE_SUCCESS) {
           // Read the rest of the bytes until we stop uplinking
           for (uint16_t i = 0; i < AX25_MAXIMUM_PKT_LEN; ++i) {
-            LOG_IF_ERROR_CODE(sciReadBytes(&rxByte, 1, pdMS_TO_TICKS(10)));
+            LOG_IF_ERROR_CODE(sciReadBytes(&rxByte, 1, portMAX_DELAY, pdMS_TO_TICKS(10)));
 
             if (errCode == OBC_ERR_CODE_SUCCESS) {
               LOG_IF_ERROR_CODE(sendToDecodeDataQueue(&rxByte));

--- a/obc/sys/logging/obc_logging.c
+++ b/obc/sys/logging/obc_logging.c
@@ -11,6 +11,8 @@
 // Extra 10 for the small extra pieces in "%s - %s\r\n"
 #define MAX_LOG_SIZE (MAX_MSG_SIZE + MAX_FNAME_LINENUM_SIZE + 10U)
 
+#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
+
 static const char *LEVEL_STRINGS[] = {"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
 
 static log_level_t logLevel;
@@ -54,7 +56,7 @@ obc_error_code_t logLog(log_level_t msgLevel, const char *file, uint32_t line, c
   if ((uint32_t)ret >= MAX_LOG_SIZE) return OBC_ERR_CODE_BUFF_TOO_SMALL;
 
   if (outputLocation == LOG_TO_UART) {
-    obc_error_code_t retSci = sciPrintText((unsigned char *)buf, sizeof(buf), portMAX_DELAY);
+    obc_error_code_t retSci = sciPrintText((unsigned char *)buf, sizeof(buf), UART_MUTEX_BLOCK_TIME);
     return retSci;
   } else if (outputLocation == LOG_TO_SDCARD) {
     // implement when SD card driver is written

--- a/obc/sys/logging/obc_logging.c
+++ b/obc/sys/logging/obc_logging.c
@@ -54,7 +54,7 @@ obc_error_code_t logLog(log_level_t msgLevel, const char *file, uint32_t line, c
   if ((uint32_t)ret >= MAX_LOG_SIZE) return OBC_ERR_CODE_BUFF_TOO_SMALL;
 
   if (outputLocation == LOG_TO_UART) {
-    obc_error_code_t retSci = sciPrintText((unsigned char *)buf, sizeof(buf));
+    obc_error_code_t retSci = sciPrintText((unsigned char *)buf, sizeof(buf), portMAX_DELAY);
     return retSci;
   } else if (outputLocation == LOG_TO_SDCARD) {
     // implement when SD card driver is written

--- a/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
+++ b/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
@@ -5,7 +5,7 @@
 void testI2C(void) {
   sciPrintf("Testing I2C...\r\n");
   uint8_t messageData[] = {0xff, 0x00, 0xff};
-  if (i2cSendTo(0x00, 3, messageData, pdMS_TO_TICKS(100), portMAX_DELAY) != OBC_ERR_CODE_SUCCESS) {
+  if (i2cSendTo(0x00, 3, messageData, portMAX_DELAY, pdMS_TO_TICKS(100)) != OBC_ERR_CODE_SUCCESS) {
     sciPrintf(
         "Failed sending message through I2C\r\n"
         "The failure might because no I2C slave device at address 0x00, "

--- a/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
+++ b/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
@@ -5,7 +5,7 @@
 void testI2C(void) {
   sciPrintf("Testing I2C...\r\n");
   uint8_t messageData[] = {0xff, 0x00, 0xff};
-  if (i2cSendTo(0x00, 3, messageData) != OBC_ERR_CODE_SUCCESS) {
+  if (i2cSendTo(0x00, 3, messageData, pdMS_TO_TICKS(100), portMAX_DELAY) != OBC_ERR_CODE_SUCCESS) {
     sciPrintf(
         "Failed sending message through I2C\r\n"
         "The failure might because no I2C slave device at address 0x00, "

--- a/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
+++ b/obc/tools/bringup/interface_debug_tool/source/test_i2c.c
@@ -2,10 +2,13 @@
 #include "obc_sci_io.h"
 #include "obc_i2c_io.h"
 
+#define I2C_MUTEX_TIMEOUT portMAX_DELAY
+#define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)
+
 void testI2C(void) {
   sciPrintf("Testing I2C...\r\n");
   uint8_t messageData[] = {0xff, 0x00, 0xff};
-  if (i2cSendTo(0x00, 3, messageData, portMAX_DELAY, pdMS_TO_TICKS(100)) != OBC_ERR_CODE_SUCCESS) {
+  if (i2cSendTo(0x00, 3, messageData, I2C_MUTEX_TIMEOUT, I2C_TRANSFER_TIMEOUT) != OBC_ERR_CODE_SUCCESS) {
     sciPrintf(
         "Failed sending message through I2C\r\n"
         "The failure might because no I2C slave device at address 0x00, "


### PR DESCRIPTION
# Purpose
Make block times configurable for RM46 and CC1120 functions.

# New Changes
Functions now take arguments for block time, no longer depending on the macros. The macros are still present in the files; however, the functions no longer use them directly. Code calling the modified functions has been updated to reflect the changes.

# Testing
Unit tests pass locally.

# Outstanding Changes
Are there any functions missed? Are there any that don't require this change?
