### PR TITLE
Suppress HAL Warnings

### DIFF
--- a/obc/hal/launchpad/source/het.c
+++ b/obc/hal/launchpad/source/het.c
@@ -43,6 +43,8 @@
 #include "het.h"
 #include "sys_vim.h"
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
 /* USER CODE END */
 
 /*----------------------------------------------------------------------------*/
@@ -1933,6 +1935,7 @@ void het1GetConfigValue(het_config_reg_t *config_reg, config_value_type_t type)
 }
 
 /* USER CODE BEGIN (5) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 
 /** @fn void het1HighLevelInterrupt(void)

--- a/obc/hal/launchpad/source/spi.c
+++ b/obc/hal/launchpad/source/spi.c
@@ -39,6 +39,8 @@
 */
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "spi.h"
@@ -1212,6 +1214,7 @@ void spiDisableNotification(spiBASE_t *spi, uint32 flags)
     spi->INT0 = (spi->INT0 & (~(flags)));
 
 /* USER CODE BEGIN (33) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 }
 

--- a/obc/hal/launchpad/source/sys_selftest.c
+++ b/obc/hal/launchpad/source/sys_selftest.c
@@ -43,6 +43,8 @@
 
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "sys_selftest.h"
@@ -2624,6 +2626,7 @@ void pbistFail(void)
         }/* Wait */
 
 /* USER CODE BEGIN (78) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
     }
 }

--- a/obc/hal/obc_rev1/source/het.c
+++ b/obc/hal/obc_rev1/source/het.c
@@ -43,6 +43,8 @@
 #include "het.h"
 #include "sys_vim.h"
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
 /* USER CODE END */
 
 /*----------------------------------------------------------------------------*/
@@ -1933,6 +1935,7 @@ void het1GetConfigValue(het_config_reg_t *config_reg, config_value_type_t type)
 }
 
 /* USER CODE BEGIN (5) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 
 /** @fn void het1HighLevelInterrupt(void)

--- a/obc/hal/obc_rev1/source/spi.c
+++ b/obc/hal/obc_rev1/source/spi.c
@@ -39,6 +39,8 @@
 */
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "spi.h"
@@ -1212,6 +1214,7 @@ void spiDisableNotification(spiBASE_t *spi, uint32 flags)
     spi->INT0 = (spi->INT0 & (~(flags)));
 
 /* USER CODE BEGIN (33) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 }
 

--- a/obc/hal/obc_rev1/source/sys_selftest.c
+++ b/obc/hal/obc_rev1/source/sys_selftest.c
@@ -43,6 +43,8 @@
 
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "sys_selftest.h"
@@ -2624,6 +2626,7 @@ void pbistFail(void)
         }/* Wait */
 
 /* USER CODE BEGIN (78) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
     }
 }

--- a/obc/hal/obc_rev2/source/het.c
+++ b/obc/hal/obc_rev2/source/het.c
@@ -43,6 +43,8 @@
 #include "het.h"
 #include "sys_vim.h"
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
 /* USER CODE END */
 
 /*----------------------------------------------------------------------------*/
@@ -1933,6 +1935,7 @@ void het1GetConfigValue(het_config_reg_t *config_reg, config_value_type_t type)
 }
 
 /* USER CODE BEGIN (5) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 
 /** @fn void het1HighLevelInterrupt(void)

--- a/obc/hal/obc_rev2/source/spi.c
+++ b/obc/hal/obc_rev2/source/spi.c
@@ -39,6 +39,8 @@
 */
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "spi.h"
@@ -1212,6 +1214,7 @@ void spiDisableNotification(spiBASE_t *spi, uint32 flags)
     spi->INT0 = (spi->INT0 & (~(flags)));
 
 /* USER CODE BEGIN (33) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
 }
 

--- a/obc/hal/obc_rev2/source/sys_selftest.c
+++ b/obc/hal/obc_rev2/source/sys_selftest.c
@@ -43,6 +43,8 @@
 
 
 /* USER CODE BEGIN (0) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 /* USER CODE END */
 
 #include "sys_selftest.h"
@@ -2624,6 +2626,7 @@ void pbistFail(void)
         }/* Wait */
 
 /* USER CODE BEGIN (78) */
+#pragma GCC diagnostic pop
 /* USER CODE END */
     }
 }


### PR DESCRIPTION
# Purpose
Explain the purpose of the PR here, including references to any existing Notion tasks.
- Suppress HAL warnings like the 30 that pop up from sys_selfTest so that it's easier to spot non hal warnings, since HAL should be completely HalCoGen generated now anyways
# New Changes
- Explain new changes
- added pragma directives to suppress unused variable warnings in certain HAL files where they were happening
# Testing
- Explain tests that you ran to verify code functionality.
- Any functions that can be unit-tested should include a unit test in the PR. Otherwise, explain why it cannot be unit-tested.

Look at the workflows
# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
