### PR TITLE
Added -Werror Flag

### DIFF
--- a/cmake/toolchain_arm_none_eabi.cmake
+++ b/cmake/toolchain_arm_none_eabi.cmake
@@ -36,15 +36,11 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # ARM specific flags
 add_compile_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)
 
-# C flags
-if(CMAKE_LANG_COMPILE STREQUAL "C")
-    add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD -std=gnu99)
-endif()
+# Common flags
+add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD)
 
-# C++ flags
-if(CMAKE_LANG_COMPILE STREQUAL "CXX")
-    add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD)
-endif()
+# Conditional flag for C code
+add_compile_options($<$<COMPILE_LANGUAGE:C>:-std=gnu99>)
 
 # Linker flags
 add_link_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)

--- a/cmake/toolchain_arm_none_eabi.cmake
+++ b/cmake/toolchain_arm_none_eabi.cmake
@@ -36,8 +36,15 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # ARM specific flags
 add_compile_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)
 
-# Common flags
-add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD -std=gnu99)
+# C flags
+if(CMAKE_LANG_COMPILE STREQUAL "C")
+    add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD -std=gnu99)
+endif()
+
+# C++ flags
+if(CMAKE_LANG_COMPILE STREQUAL "CXX")
+    add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD)
+endif()
 
 # Linker flags
 add_link_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)

--- a/cmake/toolchain_arm_none_eabi.cmake
+++ b/cmake/toolchain_arm_none_eabi.cmake
@@ -37,7 +37,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 add_compile_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)
 
 # Common flags
-add_compile_options(-Wall -Wextra -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD -std=gnu99)
+add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter -fstack-usage -fdump-ipa-cgraph -MMD -std=gnu99)
 
 # Linker flags
 add_link_options(-mcpu=cortex-r4 -march=armv7-r -mtune=cortex-r4 -marm -mfpu=vfpv3-d16)


### PR DESCRIPTION
# Purpose
Explain the purpose of the PR here, including references to any existing Notion tasks.
- Now that all of the HAL warnings are suppressed, we can enable the -Werror flag to treat all warnings as errors and have them make compilation and CI fail so that we can easily make sure nobody introduces any warnings
# New Changes
- Explain new changes

# Testing
- Explain tests that you ran to verify code functionality.
- Any functions that can be unit-tested should include a unit test in the PR. Otherwise, explain why it cannot be unit-tested.
- CI
- Tested by adding an implicit data type conversion, and the compiler treated that warning as an error
# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
