### PR TITLE
[BUGFIX] Changed hal-lib-no-optimize into static lib 

### DIFF
--- a/obc/CMakeLists.txt
+++ b/obc/CMakeLists.txt
@@ -58,5 +58,5 @@ target_link_libraries(OBC-firmware.out PRIVATE
     lib-correct
     obc-gs-interface
     ${HAL_LIB_OPTIMIZE}
-    $<TARGET_OBJECTS:${HAL_LIB_NO_OPTIMIZE}>
+    ${HAL_LIB_NO_OPTIMIZE}
 )

--- a/obc/hal/CMakeLists.txt
+++ b/obc/hal/CMakeLists.txt
@@ -144,7 +144,7 @@ target_sources(${HAL_LIB_OPTIMIZE} PUBLIC ${HAL_SOURCES})
 
 # Higher optimization levels on some hal files will break firmware for some reason
 # Compile them with no optimizations
-add_library(${HAL_LIB_NO_OPTIMIZE} OBJECT)
+add_library(${HAL_LIB_NO_OPTIMIZE} STATIC)
 target_include_directories(${HAL_LIB_NO_OPTIMIZE} PUBLIC ${HAL_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/common)
 target_sources(${HAL_LIB_NO_OPTIMIZE} PUBLIC ${NO_OPTIMIZE_SOURCES})
 

--- a/obc/tools/bringup/interface_debug_tool/CMakeLists.txt
+++ b/obc/tools/bringup/interface_debug_tool/CMakeLists.txt
@@ -41,5 +41,5 @@ target_link_libraries(debug-tool.out PRIVATE
   lib-correct
   obc-gs-interface
   ${HAL_LIB_OPTIMIZE}
-  $<TARGET_OBJECTS:${HAL_LIB_NO_OPTIMIZE}>
+  ${HAL_LIB_NO_OPTIMIZE}
 )


### PR DESCRIPTION
# Purpose
For some reason, Docker dev environment on Mac doesn't like the lib being an object lib. It was expected that the object lib would be compiled at the very end of the build process and linked in, but the build would fail before that (since it expected the lib files to be compiled earlier for some reason).

# Testing
-CI