### PR TITLE
Mike/generate binary

### DIFF
--- a/obc/CMakeLists.txt
+++ b/obc/CMakeLists.txt
@@ -60,3 +60,19 @@ target_link_libraries(OBC-firmware.out PRIVATE
     ${HAL_LIB_OPTIMIZE}
     $<TARGET_OBJECTS:${HAL_LIB_NO_OPTIMIZE}>
 )
+
+# Add OBC-firmware.bin generation to build process
+add_custom_command(
+    TARGET OBC-firmware.out
+    POST_BUILD
+    COMMAND toolchain/bin/arm-none-eabi-objcopy -O binary --only-section=.intvecs
+                                                                     --only-section=.kernelTEXT
+                                                                     --only-section=.text
+                                                                     --only-section=.ARM
+                                                                     --only-section=.preinit_array
+                                                                     --only-section=.init_array
+                                                                     --only-section=.fini_array
+                                                                     --only-section=.data
+                                                                        OBC-firmware.out OBC-firmware.bin
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Generating OBC-firmware.bin")

--- a/obc/CMakeLists.txt
+++ b/obc/CMakeLists.txt
@@ -61,10 +61,9 @@ target_link_libraries(OBC-firmware.out PRIVATE
     $<TARGET_OBJECTS:${HAL_LIB_NO_OPTIMIZE}>
 )
 
-# Add OBC-firmware.bin generation to build process
+# Add OBC-firmware.bin file generation into build process
 add_custom_command(
-    TARGET OBC-firmware.out
-    POST_BUILD
+    OUTPUT OBC-firmware.bin
     COMMAND toolchain/bin/arm-none-eabi-objcopy -O binary --only-section=.intvecs
                                                                      --only-section=.kernelTEXT
                                                                      --only-section=.text
@@ -75,4 +74,12 @@ add_custom_command(
                                                                      --only-section=.data
                                                                         OBC-firmware.out OBC-firmware.bin
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Generating OBC-firmware.bin")
+    DEPENDS OBC-firmware.out
+    COMMENT "Generating OBC-firmware.bin"
+)
+
+add_custom_target(
+    OBC-firmware_bin
+    ALL
+    DEPENDS OBC-firmware.bin
+)


### PR DESCRIPTION
# Purpose
Incorporate .bin file generation into build step for OBC-firmware for flashing via bootloader.

# New Changes
Added a new target and custom command for generating OBC-firmware.bin that is dependent on OBC-firmware.out

# Testing
- Built OBC-firmware to make sure that OBC-firmware.bin is being built
- Ensured that OBC-firmware.bin is dependent on OBC-firmware.out
- Ensured that OBC-firmware.bin is being built even if OBC-firmware.out already exists

# Outstanding Changes