### PR TITLE
[BUGFIX] GNC mgr WDT checkin causing watchdog reset

### DIFF
--- a/obc/modules/gnc_mgr/gnc_manager.c
+++ b/obc/modules/gnc_mgr/gnc_manager.c
@@ -1,7 +1,7 @@
 #include "gnc_manager.h"
-#include "obc_digital_watchdog.h"
 #include "obc_errors.h"
 #include "obc_scheduler_config.h"
+#include "digital_watchdog_mgr.h"
 
 #include <FreeRTOS.h>
 #include <os_portmacro.h>
@@ -22,7 +22,7 @@ void obcTaskFunctionGncMgr(void *pvParameters) {
 
   /* Run GNC tasks periodically at 20 Hz */
   while (1) {
-    feedDigitalWatchdog();
+    digitalWatchdogTaskCheckIn(OBC_SCHEDULER_CONFIG_ID_GNC_MGR);
 
     /* This will automatically update the xLastWakeTime variable to be the last unblocked time */
     vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(GNC_TASK_PERIOD_MS));


### PR DESCRIPTION
# Purpose
Fixed bug where watchdog was resetting MCU due to GNC mgr not checking in.