### PR TITLE
Simultaneous Bootloader Logging

### DIFF
--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -93,28 +93,28 @@ int main(void) {
 
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
+          char blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
           int32_t blUartWriteBufferLen =
               snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
           if (blUartWriteBufferLen < 0) {
             blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),
                              (uint8_t *)"Error with processing message buffer length\r\n");
           }
-          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, blUartWriteBuffer);
+          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, (uint8_t *)blUartWriteBuffer);
           state = BL_STATE_IDLE;
           break;
         }
 
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
+          char blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
           int32_t blUartWriteBufferLen =
               snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
           if (blUartWriteBufferLen < 0) {
             blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),
                              (uint8_t *)"Error with processing message buffer length\r\n");
           }
-          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, blUartWriteBuffer);
+          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, (uint8_t *)blUartWriteBuffer);
           state = BL_STATE_IDLE;
           break;
         }

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -92,16 +92,18 @@ int main(void) {
 
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to init flash, error code: %d\r\n", errCode),
-                           (uint8_t *)"Failed to init flash, error code: %d\r\n", errCode);
+          int errCodeLength = strlen("Failed to init flash, error code: ") + strlen("%d\r\n", errCode);
+          blUartWriteBytes(BL_UART_SCIREG, errCodeLength, (uint8_t *)"Failed to init flash, error code: %d\r\n",
+                           errCode);
           state = BL_STATE_IDLE;
           break;
         }
 
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to erase flash, error code: %d\r\n", errCode),
-                           (uint8_t *)"Failed to init flash, error code: %d\r\n", errCode);
+          int errCodeLength = strlen("Failed to init flash, error code: ") + strlen("%d\r\n", errCode);
+          blUartWriteBytes(BL_UART_SCIREG, errCodeLength, (uint8_t *)"Failed to init flash, error code: %d\r\n",
+                           errCode);
           state = BL_STATE_IDLE;
           break;
         }

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -94,7 +94,7 @@ int main(void) {
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
           uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
-          uint32_t blUartWriteBufferLen =
+          int32_t blUartWriteBufferLen =
               snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
           if (blUartWriteBufferLen < 0) {
             blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),
@@ -108,7 +108,7 @@ int main(void) {
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
           uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
-          uint32_t blUartWriteBufferLen =
+          int32_t blUartWriteBufferLen =
               snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
           if (blUartWriteBufferLen < 0) {
             blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -17,6 +17,7 @@ extern uint32_t __ramFuncsRunEnd__;
 // use too much RAM
 #define BL_BIN_RX_CHUNK_SIZE 128U   // Bytes
 #define BL_ECC_FIX_CHUNK_SIZE 128U  // Bytes
+#define BL_MAX_MSG_SIZE 64U
 
 /* TYPEDEFS */
 typedef void (*appStartFunc_t)(void);
@@ -92,18 +93,28 @@ int main(void) {
 
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          int errCodeLength = strlen("Failed to init flash, error code: ") + strlen("%d\r\n", errCode);
-          blUartWriteBytes(BL_UART_SCIREG, errCodeLength, (uint8_t *)"Failed to init flash, error code: %d\r\n",
-                           errCode);
+          uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
+          uint32_t blUartWriteBufferLen =
+              snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
+          if (blUartWriteBufferLen < 0) {
+            blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),
+                             (uint8_t *)"Error with processing message buffer length\r\n");
+          }
+          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, blUartWriteBuffer);
           state = BL_STATE_IDLE;
           break;
         }
 
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          int errCodeLength = strlen("Failed to init flash, error code: ") + strlen("%d\r\n", errCode);
-          blUartWriteBytes(BL_UART_SCIREG, errCodeLength, (uint8_t *)"Failed to init flash, error code: %d\r\n",
-                           errCode);
+          uint8_t blUartWriteBuffer[BL_MAX_MSG_SIZE] = {0};
+          uint32_t blUartWriteBufferLen =
+              snprintf(blUartWriteBuffer, BL_MAX_MSG_SIZE, "Failed to init flash, error code: %d\r\n", errCode);
+          if (blUartWriteBufferLen < 0) {
+            blUartWriteBytes(BL_UART_SCIREG, strlen("Error with processing message buffer length\r\n"),
+                             (uint8_t *)"Error with processing message buffer length\r\n");
+          }
+          blUartWriteBytes(BL_UART_SCIREG, blUartWriteBufferLen, blUartWriteBuffer);
           state = BL_STATE_IDLE;
           break;
         }

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -50,10 +50,10 @@ int main(void) {
   while (1) {
     switch (state) {
       case BL_STATE_IDLE: {
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Waiting for input\r\n"), (uint8_t *)"Waiting for input\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Waiting for input\r\n"), (uint8_t *)"Waiting for input\r\n");
 
         char c = '\0';
-        blUartReadBytes(BL_UART_SCIREG_2, (uint8_t *)&c, 1);
+        blUartReadBytes(BL_UART_SCIREG, (uint8_t *)&c, 1);
 
         if (c == 'd') {
           state = BL_STATE_DOWNLOAD_IMAGE;
@@ -66,53 +66,51 @@ int main(void) {
         break;
       }
       case BL_STATE_DOWNLOAD_IMAGE: {
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Downloading application\r\n"),
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Downloading application\r\n"),
                          (uint8_t *)"Downloading application\r\n");
 
         uint8_t recvBuffer[sizeof(app_header_t)] = {0U};
 
-        blUartReadBytes(BL_UART_SCIREG_2, recvBuffer, sizeof(app_header_t));
+        blUartReadBytes(BL_UART_SCIREG, recvBuffer, sizeof(app_header_t));
 
         app_header_t appHeader = {0};
         memcpy((void *)&appHeader, (void *)recvBuffer, sizeof(app_header_t));
 
         if (appHeader.size == 0U) {
-          blUartWriteBytes(BL_UART_SCIREG_1, strlen("Invalid image size\r\n"), (uint8_t *)"Invalid image size\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Invalid image size\r\n"), (uint8_t *)"Invalid image size\r\n");
           state = BL_STATE_IDLE;
           break;
         }
 
         if (!blFlashIsStartAddrValid(APP_START_ADDRESS, appHeader.size)) {
-          blUartWriteBytes(BL_UART_SCIREG_1, strlen("Invalid start address\r\n"),
-                           (uint8_t *)"Invalid start address\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Invalid start address\r\n"), (uint8_t *)"Invalid start address\r\n");
           state = BL_STATE_IDLE;
           break;
         }
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Received header\r\n"), (uint8_t *)"Received header\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Received header\r\n"), (uint8_t *)"Received header\r\n");
 
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG_1, strlen("Failed to init flash\r\n"), (uint8_t *)"Failed to init flash\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to init flash\r\n"), (uint8_t *)"Failed to init flash\r\n");
           state = BL_STATE_IDLE;
           break;
         }
 
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG_1, strlen("Failed to erase flash\r\n"),
-                           (uint8_t *)"Failed to erase flash\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to erase flash\r\n"), (uint8_t *)"Failed to erase flash\r\n");
           state = BL_STATE_IDLE;
           break;
         }
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Erased flash\r\n"), (uint8_t *)"Erased flash\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Erased flash\r\n"), (uint8_t *)"Erased flash\r\n");
 
         // Host will send a 'D' before sending the image
         while (1) {
           char waitChar = '\0';
 
-          blUartReadBytes(BL_UART_SCIREG_2, (uint8_t *)&waitChar, 1U);
+          blUartReadBytes(BL_UART_SCIREG, (uint8_t *)&waitChar, 1U);
 
           if (waitChar == 'D') {
             break;
@@ -129,7 +127,7 @@ int main(void) {
           uint32_t numBytesToRead =
               (numAppBytesToFlash > BL_BIN_RX_CHUNK_SIZE) ? BL_BIN_RX_CHUNK_SIZE : numAppBytesToFlash;
 
-          blUartReadBytes(BL_UART_SCIREG_2, recvBuffer, numBytesToRead);
+          blUartReadBytes(BL_UART_SCIREG, recvBuffer, numBytesToRead);
 
           blFlashFapiBlockWrite(APP_START_ADDRESS + (appHeader.size - numAppBytesToFlash), (uint32_t)recvBuffer,
                                 numBytesToRead);
@@ -137,9 +135,9 @@ int main(void) {
           numAppBytesToFlash -= numBytesToRead;
         }
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Wrote application\r\n"), (uint8_t *)"Wrote application\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Wrote application\r\n"), (uint8_t *)"Wrote application\r\n");
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Fixing ECC\r\n"), (uint8_t *)"Fixing ECC\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Fixing ECC\r\n"), (uint8_t *)"Fixing ECC\r\n");
 
         // Fix the ECC for any flash memory that was erased, but not overwritten by the new app
         uint8_t eccFixWriteBuf[BL_ECC_FIX_CHUNK_SIZE] = {0U};
@@ -162,14 +160,14 @@ int main(void) {
           eccFixBytesLeft -= numBytesToWrite;
         }
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Finished writing to flash\r\n"),
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Finished writing to flash\r\n"),
                          (uint8_t *)"Finished writing to flash\r\n");
 
         state = BL_STATE_IDLE;
         break;
       }
       case BL_STATE_ERASE_IMAGE: {
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("NOT IMPLEMENTED\r\n"), (uint8_t *)"NOT IMPLEMENTED\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("NOT IMPLEMENTED\r\n"), (uint8_t *)"NOT IMPLEMENTED\r\n");
 
         // TODO: Erase entire application space
 
@@ -177,13 +175,13 @@ int main(void) {
         break;
       }
       case BL_STATE_RUN_APP: {
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Running application\r\n"), (uint8_t *)"Running application\r\n");
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Running application\r\n"), (uint8_t *)"Running application\r\n");
 
         // Go to the application's entry point
         uint32_t appStartAddress = (uint32_t)APP_START_ADDRESS;
         ((appStartFunc_t)appStartAddress)();
 
-        blUartWriteBytes(BL_UART_SCIREG_1, strlen("Failed to run application\r\n"),
+        blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to run application\r\n"),
                          (uint8_t *)"Failed to run application\r\n");
 
         // TODO: Restart device if application fails to run or returns

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -1,7 +1,7 @@
 #include "bl_config.h"
 #include "bl_flash.h"
 #include "bl_uart.h"
-
+#include "bl_errors.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -92,14 +92,16 @@ int main(void) {
 
         errCode = blFlashFapiInitBank(0U);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to init flash\r\n"), (uint8_t *)"Failed to init flash\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to init flash, error code: %d\r\n", errCode),
+                           (uint8_t *)"Failed to init flash, error code: %d\r\n", errCode);
           state = BL_STATE_IDLE;
           break;
         }
 
         errCode = blFlashFapiBlockErase(APP_START_ADDRESS, appHeader.size);
         if (errCode != BL_ERR_CODE_SUCCESS) {
-          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to erase flash\r\n"), (uint8_t *)"Failed to erase flash\r\n");
+          blUartWriteBytes(BL_UART_SCIREG, strlen("Failed to erase flash, error code: %d\r\n", errCode),
+                           (uint8_t *)"Failed to init flash, error code: %d\r\n", errCode);
           state = BL_STATE_IDLE;
           break;
         }

--- a/obc/bl/include/bl_uart.h
+++ b/obc/bl/include/bl_uart.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include "obc_board_config.h"
 #include <stdint.h>
 
 typedef enum {
-  BL_UART_SCIREG_1 = 0,
-  BL_UART_SCIREG_2 = 1,
   BL_UART_SCIREG = 0,
 } bl_uart_reg_t;
 

--- a/obc/bl/include/bl_uart.h
+++ b/obc/bl/include/bl_uart.h
@@ -3,8 +3,7 @@
 #include <stdint.h>
 
 typedef enum {
-  BL_UART_SCIREG_1 = 0,
-  BL_UART_SCIREG_2 = 1,
+  BL_UART_SCIREG = 0,
 } bl_uart_reg_t;
 
 /**

--- a/obc/bl/include/bl_uart.h
+++ b/obc/bl/include/bl_uart.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 
 typedef enum {
+  BL_UART_SCIREG_1 = 0,
+  BL_UART_SCIREG_2 = 1,
   BL_UART_SCIREG = 0,
 } bl_uart_reg_t;
 

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -1,14 +1,11 @@
 #include "bl_uart.h"
 
 #include <sci.h>
-
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 
 /* DEFINES */
-#define BL_UART_SCIREG_1_BAUD 115200U
-#define BL_UART_SCIREG_2_BAUD 115200U
 #define BL_UART_SCIREG_BAUD 115200U
 
 /* TYPEDEFS */
@@ -19,9 +16,7 @@ typedef struct {
 
 /* PRIVATE VARIABLES */
 static const bl_uart_reg_config_t bl_uart_reg_config[] = {
-    [BL_UART_SCIREG_1] = {BL_UART_SCIREG_1_BAUD, sciREG},
-    [BL_UART_SCIREG_2] = {BL_UART_SCIREG_2_BAUD, scilinREG},
-    [BL_UART_SCIREG] = {BL_UART_SCIREG_BAUD, sciREG},
+    [BL_UART_SCIREG] = {BL_UART_SCIREG_BAUD, UART_BL_REG},
 };
 
 /* PUBLIC FUNCTIONS */

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -7,8 +7,7 @@
 #include <stdio.h>
 
 /* DEFINES */
-#define BL_UART_SCIREG_1_BAUD 115200U
-#define BL_UART_SCIREG_2_BAUD 115200U
+#define BL_UART_SCIREG_BAUD 115200U
 
 /* TYPEDEFS */
 typedef struct {
@@ -18,16 +17,14 @@ typedef struct {
 
 /* PRIVATE VARIABLES */
 static const bl_uart_reg_config_t bl_uart_reg_config[] = {
-    [BL_UART_SCIREG_1] = {BL_UART_SCIREG_1_BAUD, sciREG},
-    [BL_UART_SCIREG_2] = {BL_UART_SCIREG_2_BAUD, scilinREG},
+    [BL_UART_SCIREG] = {BL_UART_SCIREG_BAUD, sciREG},
 };
 
 /* PUBLIC FUNCTIONS */
 void blUartInit(void) {
   sciInit();
 
-  sciSetBaudrate(bl_uart_reg_config[BL_UART_SCIREG_1].sciReg, bl_uart_reg_config[BL_UART_SCIREG_1].baud);
-  sciSetBaudrate(bl_uart_reg_config[BL_UART_SCIREG_2].sciReg, bl_uart_reg_config[BL_UART_SCIREG_2].baud);
+  sciSetBaudrate(bl_uart_reg_config[BL_UART_SCIREG].sciReg, bl_uart_reg_config[BL_UART_SCIREG].baud);
 }
 
 void blUartReadBytes(bl_uart_reg_t reg, uint8_t *buf, uint32_t numBytes) {

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 
 /* DEFINES */
+#define BL_UART_SCIREG_1_BAUD 115200U
+#define BL_UART_SCIREG_2_BAUD 115200U
 #define BL_UART_SCIREG_BAUD 115200U
 
 /* TYPEDEFS */
@@ -17,6 +19,8 @@ typedef struct {
 
 /* PRIVATE VARIABLES */
 static const bl_uart_reg_config_t bl_uart_reg_config[] = {
+    [BL_UART_SCIREG_1] = {BL_UART_SCIREG_1_BAUD, sciREG},
+    [BL_UART_SCIREG_2] = {BL_UART_SCIREG_2_BAUD, scilinREG},
     [BL_UART_SCIREG] = {BL_UART_SCIREG_BAUD, sciREG},
 };
 

--- a/obc/shared/config/obc_board_config.h
+++ b/obc/shared/config/obc_board_config.h
@@ -9,6 +9,7 @@
 #define UART_PRINT_REG scilinREG
 #define UART_READ_REG scilinREG
 #define UART_VN100_REG sciREG
+#define UART_BL_REG scilinREG
 
 // Fram SPI config
 #define FRAM_spiREG spiREG3
@@ -57,6 +58,7 @@
 #define UART_PRINT_REG sciREG
 #define UART_READ_REG sciREG
 #define UART_VN100_REG scilinREG
+#define UART_BL_REG sciREG
 
 // Fram SPI config
 #define FRAM_spiREG spiREG1
@@ -105,6 +107,7 @@
 #define UART_PRINT_REG sciREG
 #define UART_READ_REG sciREG
 #define UART_VN100_REG scilinREG
+#define UART_BL_REG sciREG
 
 // Fram SPI config
 #define FRAM_spiREG spiREG5

--- a/obc/tools/python/bin_formatter.py
+++ b/obc/tools/python/bin_formatter.py
@@ -114,7 +114,6 @@ async def send_bin(file_path: str, com_port: str) -> None:
             else:
                 ser.write(data[num_bytes_written + 8 :])
                 num_bytes_written += total_bytes_to_write - num_bytes_written
-                await asyncio.sleep(0.1)
 
             print(f"{num_bytes_written}/{total_bytes_to_write} bytes sent")
 
@@ -141,8 +140,8 @@ async def read_log(com_port: str) -> None:
                 log_line = ser.readline().decode("utf-8")
                 if log_line:
                     log_reader.info(log_line)
-        except serial.SerialException:
-            log_reader.error(log_line)
+        except serial.SerialException as e:
+            log_reader.error(e)
 
 
 def arg_parse() -> ArgumentParser:
@@ -151,7 +150,7 @@ def arg_parse() -> ArgumentParser:
 
     :return: Parser object
     """
-    parser = ArgumentParser(description="Append custom data to .bin, send amd log_reader")
+    parser = ArgumentParser(description="Append custom data to .bin and send")
 
     # Add arguments
     parser.add_argument(

--- a/obc/tools/python/bin_formatter.py
+++ b/obc/tools/python/bin_formatter.py
@@ -141,7 +141,7 @@ async def read_log(com_port: str) -> None:
                 if log_line:
                     log_reader.info(log_line)
         except serial.SerialException as e:
-            log_reader.error(e)
+            log_reader.exception(e)
 
 
 def arg_parse() -> ArgumentParser:
@@ -160,10 +160,8 @@ def arg_parse() -> ArgumentParser:
         type=str,
         help="Path to the input .bin file.",
     )
-    parser.add_argument("-p_bin", required=True, dest="bin_port", type=str, help="Serial port number")
-    parser.add_argument(
-        "-p_read", required=True, dest="read_port", type=str, help="Serial port number used to read logs"
-    )
+    parser.add_argument("-p", required=True, dest="port", type=str, help="Serial port number")
+
     parser.add_argument(
         "-v",
         dest="version",
@@ -181,8 +179,8 @@ async def main() -> None:
     args = arg_parser.parse_args()
     output_file = create_bin(args.input_path, args.version)
     await asyncio.gather(
-        send_bin(output_file, args.bin_port),
-        read_log(args.read_port),
+        send_bin(output_file, args.port),
+        read_log(args.port),
     )
 
 

--- a/obc/tools/python/bin_formatter.py
+++ b/obc/tools/python/bin_formatter.py
@@ -1,6 +1,7 @@
+import asyncio
 import dataclasses
+import logging
 import struct
-import time
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Final
@@ -8,6 +9,10 @@ from typing import Final
 import serial
 
 OBC_UART_BAUD_RATE: Final = 115200
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+bin_header_logger = logging.getLogger("bin_header_logger")
+log_reader = logging.getLogger("log_reader")
 
 
 @dataclasses.dataclass
@@ -47,7 +52,7 @@ def create_bin(input_path: str, input_version: int) -> str:
     header = BootloaderHeader(version=input_version, bin_size=program_size_bytes)
     header_bytes = header.serialize()
 
-    print(header)  # TODO: Replace with logging
+    bin_header_logger.info(header)
 
     output_path = input_path.replace(".bin", "_formatted.bin")
     output_obj = Path(output_path)
@@ -56,7 +61,7 @@ def create_bin(input_path: str, input_version: int) -> str:
     return output_path
 
 
-def send_bin(file_path: str, com_port: str) -> None:
+async def send_bin(file_path: str, com_port: str) -> None:
     """
     Sends .bin file over UART serial port
 
@@ -82,11 +87,11 @@ def send_bin(file_path: str, com_port: str) -> None:
 
         # Start program download
         ser.write("d".encode("ascii"))
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
 
         # Send header
         ser.write(data[0 : BootloaderHeader.get_header_size()])
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
 
         # Wait for user to initiate transfer
         while input("Enter 1 to start program transfer: ") != "1":
@@ -94,7 +99,7 @@ def send_bin(file_path: str, com_port: str) -> None:
 
         # Bootloader expects a 'D' to be sent before the app
         ser.write("D".encode("ascii"))
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
 
         # Send app in chunks of 128 bytes
         total_bytes_to_write = len(data) - BootloaderHeader.get_header_size()
@@ -105,14 +110,39 @@ def send_bin(file_path: str, com_port: str) -> None:
             if total_bytes_to_write - num_bytes_written >= chunk_size:
                 ser.write(data[8 + num_bytes_written : 8 + num_bytes_written + chunk_size])
                 num_bytes_written += chunk_size
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
             else:
                 ser.write(data[num_bytes_written + 8 :])
                 num_bytes_written += total_bytes_to_write - num_bytes_written
+                await asyncio.sleep(0.1)
 
             print(f"{num_bytes_written}/{total_bytes_to_write} bytes sent")
 
         print("Done writing app")
+
+
+async def read_log(com_port: str) -> None:
+    """
+    Reads logs from a specific port
+
+    :param com_port: Com port for UART communication
+    """
+
+    with serial.Serial(
+        com_port,
+        baudrate=OBC_UART_BAUD_RATE,
+        parity=serial.PARITY_NONE,
+        stopbits=serial.STOPBITS_TWO,
+        timeout=1,
+    ) as ser:
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+                log_line = ser.readline().decode("utf-8")
+                if log_line:
+                    log_reader.info(log_line)
+        except serial.SerialException:
+            log_reader.error(log_line)
 
 
 def arg_parse() -> ArgumentParser:
@@ -121,7 +151,7 @@ def arg_parse() -> ArgumentParser:
 
     :return: Parser object
     """
-    parser = ArgumentParser(description="Append custom data to .bin and send")
+    parser = ArgumentParser(description="Append custom data to .bin, send amd log_reader")
 
     # Add arguments
     parser.add_argument(
@@ -131,7 +161,10 @@ def arg_parse() -> ArgumentParser:
         type=str,
         help="Path to the input .bin file.",
     )
-    parser.add_argument("-p", required=True, dest="port", type=str, help="Serial port number")
+    parser.add_argument("-p_bin", required=True, dest="bin_port", type=str, help="Serial port number")
+    parser.add_argument(
+        "-p_read", required=True, dest="read_port", type=str, help="Serial port number used to read logs"
+    )
     parser.add_argument(
         "-v",
         dest="version",
@@ -143,14 +176,16 @@ def arg_parse() -> ArgumentParser:
     return parser
 
 
-def main() -> None:
+async def main() -> None:
     """Entry point to script"""
     arg_parser = arg_parse()
     args = arg_parser.parse_args()
-
     output_file = create_bin(args.input_path, args.version)
-    send_bin(output_file, args.port)
+    await asyncio.gather(
+        send_bin(output_file, args.bin_port),
+        read_log(args.read_port),
+    )
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
# Purpose
Updated python program to send binary file and read logs simultaneously and cleaned up ports for bootloader. 
Ticket: https://www.notion.so/uworbital/Update-host-programming-tool-to-capture-all-bootloader-logs-6698bdf3563e4760b1dd166f7d14ac80

# New Changes
- Updated bin_formatter.py to read logs from any port while sending the binary file
- Updated bl_uart.h, bl_uart.c and bl_main.c so that the bootloader reads the binary 

# Testing
- Can run the code on the RM46 to see if it receives the bin file and if the computer can read logs for the MCU. 

# Outstanding Changes
- Improve transfer protocol for send_bin()
