### PR TITLE
Improve ephemeris.py's handling of julian date conversion (#288)

### DIFF
--- a/gs/sun/README.md
+++ b/gs/sun/README.md
@@ -6,6 +6,7 @@ Script for parsing data from the NASA Horizons API used by GNC for onboard algor
 Check the requirements.txt file for the latest version of the requirements (pip install -r requirements.txt)
 - Python
 - Requests (pip install requests)
+- Skyfield (pip install skyfield)
 - PyTest (pip install pytest)
 
 ## Usage:
@@ -47,7 +48,3 @@ show this help message and exit
 ### JD calculation:
 JD = min_jd + i * step_size <br>
 Where i = 0, 1, 2, ..., n-1
-
-## Testing
-Make sure you have `pytest` installed before this.
-Navigate to the `gs\sun` or `gs\sun\test` directory and run `pytest` in the command line

--- a/gs/sun/ephemeris.py
+++ b/gs/sun/ephemeris.py
@@ -17,13 +17,12 @@ from typing import BinaryIO, Final
 
 # 3rd party imports
 import requests
+from skyfield.api import load
 
 # Script constants
 SUPPORTED_VERSION: Final[str] = "1.2"
 NUMBER_OF_HEADER_DOUBLES: Final[int] = 2
 RELATIVE_TOLERANCE: Final[float] = 1e-7
-JD_OF_JANUARY_1_2000: Final[float] = 2_451_544.5
-JANUARY_1_2000: Final[datetime.date] = datetime.date(year=2000, month=1, day=1)
 API_LIMIT: Final[int] = 90_000
 
 # Print values
@@ -180,7 +179,9 @@ def is_valid_date(date: str) -> bool:
     if not time_regex.match(date):
         return False
     try:
-        to_date(date)
+        year, month, day = date.split("-")
+        datetime.date(year=int(year), month=int(month), day=int(day))
+
         return True
     except ValueError:
         return False
@@ -207,9 +208,13 @@ def convert_date_to_jd(time: str) -> float:
     """
     if time.startswith("JD"):
         return float(time[2:])
-    difference = to_date(time) - JANUARY_1_2000
 
-    return JD_OF_JANUARY_1_2000 + difference.days
+    timescale = load.timescale()
+
+    base_date = datetime.datetime.fromisoformat(time).replace(tzinfo=datetime.timezone.utc)
+    sky_date = timescale.from_datetime(base_date)
+
+    return float(sky_date.ut1)
 
 
 def validate_input(start_time: str, stop_time: str, step_size: str, output: str) -> ErrorCode:
@@ -376,12 +381,6 @@ def write_header(
         # Write the count to the file
         byte_count = struct.pack(DATA_UINT, int(count))
         file.write(bytearray(byte_count))
-
-
-def to_date(date: str) -> datetime.date:
-    """Converts the given string to a date"""
-    year, month, day = date.split("-")
-    return datetime.date(year=int(year), month=int(month), day=int(day))
 
 
 def calculate_number_of_data_points(start_time: float, stop_time: float, step_size: str) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ exclude = [
 mypy_path = "gs:obc/tools/python"
 strict = true
 
+[[tool.mypy.overrides]]
+module = "skyfield.*"
+ignore_missing_imports = true
+
 [tool.ruff]
 include = ["pyproject.toml", "gs/**/*.py", "obc/tools/python/**/*.py"]
 exclude = [

--- a/python_test/test_ephemeris.py
+++ b/python_test/test_ephemeris.py
@@ -262,6 +262,8 @@ def test_suppress_logging(caplog, level, count, msg, func, expected):
         ("2023-07-20", "2023-07-25", "1d", "output.bin.bin", ErrorCode.SUCCESS),
         ("JD", "JD100", "1d", "output.bin", ErrorCode.INVALID_DATE_TIME),
         ("JD100", "JD", "1d", "output.bin", ErrorCode.INVALID_DATE_TIME),
+        ("2023-02-27", "2023-02-29", "1d", "output.bin", ErrorCode.INVALID_DATE_TIME),  # Testing leap date behaviour
+        ("2024-02-27", "2024-02-29", "1d", "output.bin", ErrorCode.SUCCESS),
         ("2023-07-20", "2023-07-25", "10w", "output.bin", ErrorCode.INVALID_STEP_SIZE),
         ("2023-07-20", "2023-07-25", "10d", "output.bin", ErrorCode.SUCCESS),
         (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Regular dependencies
 requests==2.31.0
 pyserial==3.5
+skyfield==1.48
 
 # Typed packages
 types-requests==2.31.0


### PR DESCRIPTION
# Purpose
Improve the handling of Julian dates in ephemeris.py by using a library to parse from standard date formats to julian dates (task [here](https://uworbital.notion.site/Make-ephemeris-py-script-use-proper-JD-conversion-841074532a054c3889d93e596b317fd9))

# New Changes
- Added skyfield to python dependencies and made changes to ephemeris.py's parsing of date inputs.

# Testing
- Added a couple unit test cases for verification of proper handling of leap dates
- Ran and passed all python unit tests

# Outstanding Changes
- N/A

# Purpose
Explain the purpose of the PR here, including references to any existing Notion tasks.

# New Changes
- Explain new changes

# Testing
- Explain tests that you ran to verify code functionality.
- Any functions that can be unit-tested should include a unit test in the PR. Otherwise, explain why it cannot be unit-tested.

# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
