### PR TITLE
Decoupling persistent from alarm mgr

### DIFF
--- a/obc/app/modules/alarm_mgr/alarm_handler.c
+++ b/obc/app/modules/alarm_mgr/alarm_handler.c
@@ -17,6 +17,7 @@
 #define ALARM_HANDLER_QUEUE_ITEM_SIZE sizeof(alarm_handler_event_t)
 #define ALARM_HANDLER_QUEUE_RX_WAIT_PERIOD pdMS_TO_TICKS(10)
 #define ALARM_HANDLER_QUEUE_TX_WAIT_PERIOD pdMS_TO_TICKS(10)
+#define OBC_PERSISTENT_MAX_SUBINDEX_ALARM 24U
 
 static QueueHandle_t alarmHandlerQueueHandle;
 static StaticQueue_t alarmHandlerQueue;

--- a/obc/app/modules/alarm_mgr/alarm_handler.c
+++ b/obc/app/modules/alarm_mgr/alarm_handler.c
@@ -5,7 +5,6 @@
 #include "obc_logging.h"
 #include "obc_time.h"
 #include "obc_time_utils.h"
-#include "obc_persistent.h"
 #include "obc_assert.h"
 
 #include <FreeRTOS.h>

--- a/obc/app/sys/persistent/obc_persistent.h
+++ b/obc/app/sys/persistent/obc_persistent.h
@@ -5,7 +5,6 @@
 #include <stdbool.h>
 
 #include "obc_errors.h"
-#include "obc_gs_command_data.h"
 
 /*---------------------------------------------------------------------------*/
 /* GUIDE FOR ADDING A NEW PERSISTENT SECTION:
@@ -67,7 +66,7 @@ typedef struct {
 
 /* SECTION AND DATA STRUCTS */
 
-// obc_time module
+/* obc_time module */
 typedef struct {
   uint32_t unixTime;
 } obc_time_persist_data_t;
@@ -77,13 +76,44 @@ typedef struct {
   obc_time_persist_data_t data;
 } obc_time_persist_t;
 
-// alarm_mgr module
+/* alarm_mgr module */
+
+// Command ID definition for persistent
+typedef enum {
+  CMD_END_OF_FRAME_PERSIST = 0x00,
+  CMD_EXEC_OBC_RESET_PERSIST,
+  CMD_RTC_SYNC_PERSIST,
+  CMD_DOWNLINK_LOGS_NEXT_PASS_PERSIST,
+  CMD_MICRO_SD_FORMAT_PERSIST,
+  CMD_PING_PERSIST,
+  CMD_DOWNLINK_TELEM_PERSIST,
+  NUM_CMD_CALLBACKS_PERSIST
+} cmd_callback_id_persist_t;
+
+// Command data structures for persistent
+typedef struct {
+  uint32_t unixTime;
+} rtc_sync_cmd_data_persist_t;
+typedef struct {
+  uint8_t logLevel;
+} downlink_logs_next_pass_cmd_data_persist_t;
+
+// Command message definition for persistent
+typedef struct {
+  union {
+    rtc_sync_cmd_data_persist_t rtcSync;
+    downlink_logs_next_pass_cmd_data_persist_t downlinkLogsNextPass;
+  };
+  uint32_t timestamp;
+  bool isTimeTagged;
+  cmd_callback_id_persist_t id;
+} cmd_msg_persist_t;
+
 // Alarm handler callback definition for persistent
 typedef union {
   obc_error_code_t (*defaultCallback)(void);
-  obc_error_code_t (*cmdCallback)(cmd_msg_t *);
+  obc_error_code_t (*cmdCallback)(cmd_msg_persist_t *);
 } alarm_handler_callback_def_persist_t;
-
 typedef enum {
   ALARM_TYPE_DEFAULT_PERSIST,
   ALARM_TYPE_TIME_TAGGED_CMD_PERSIST,
@@ -94,7 +124,7 @@ typedef struct {
   alarm_type_persist_t type;
   alarm_handler_callback_def_persist_t callbackDef;
   union {
-    cmd_msg_t cmdMsg;
+    cmd_msg_persist_t cmdMsg;
   };
 } alarm_mgr_persist_data_t;
 

--- a/obc/app/sys/persistent/obc_persistent.h
+++ b/obc/app/sys/persistent/obc_persistent.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 #include "obc_errors.h"
-#include "alarm_handler.h"
+#include "obc_gs_command_data.h"
 
 /*---------------------------------------------------------------------------*/
 /* GUIDE FOR ADDING A NEW PERSISTENT SECTION:
@@ -78,10 +78,21 @@ typedef struct {
 } obc_time_persist_t;
 
 // alarm_mgr module
+// Alarm handler callback definition for persistent
+typedef union {
+  obc_error_code_t (*defaultCallback)(void);
+  obc_error_code_t (*cmdCallback)(cmd_msg_t *);
+} alarm_handler_callback_def_persist_t;
+
+typedef enum {
+  ALARM_TYPE_DEFAULT_PERSIST,
+  ALARM_TYPE_TIME_TAGGED_CMD_PERSIST,
+} alarm_type_persist_t;
+
 typedef struct {
   uint32_t unixTime;
-  alarm_type_t type;
-  alarm_handler_callback_def_t callbackDef;
+  alarm_type_persist_t type;
+  alarm_handler_callback_def_persist_t callbackDef;
   union {
     cmd_msg_t cmdMsg;
   };

--- a/test/test_obc/unit/test_obc_persistent.cpp
+++ b/test/test_obc/unit/test_obc_persistent.cpp
@@ -87,7 +87,7 @@ static void writeToAllAlarms() {
   for (uint32_t i = 0; i < OBC_PERSISTENT_MAX_SUBINDEX_ALARM; ++i) {
     alarm_mgr_persist_data_t alarmIn = {
         .unixTime = i,
-        .type = ALARM_TYPE_TIME_TAGGED_CMD,
+        .type = ALARM_TYPE_TIME_TAGGED_CMD_PERSIST,
     };
     ASSERT_EQ(setPersistentDataByIndex(OBC_PERSIST_SECTION_ID_ALARM_MGR, i, &alarmIn, sizeof(alarm_mgr_persist_data_t)),
               OBC_ERR_CODE_SUCCESS);


### PR DESCRIPTION
# Purpose
The purpose is to decouple obc_persistent, a significant failure mode, from other non-persistent components such as alarm manager and command manager.
[Link to Notion](https://www.notion.so/uworbital/6375c5c5dcf1485e8a6c47f18d419ae5?v=3500916a14b64c83ab91012135c9230d&p=78fee77671ce453384f6013e2e96c312&pm=s)

# New Changes
- Reducing direct dependency between obc_persistent and alarm manager by deleting #include directives alarm_handler.h in persistent and #include obc_persistent.h in alarm manager
- Redefined needed alarm manger enum and union types + command message struct in persistent (cmd_msg_persist_t)

# Testing
- Ran integration tests and passed

# Outstanding Changes
- N/A
