### PR TITLE
[BUGFIX] Fix bootloop due to GNC mgr watchdog biting

### DIFF
--- a/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
+++ b/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
@@ -10,6 +10,7 @@
 
 // Must feed the watchdog before the timeout period expires
 // This value should provide some margin
+// Should be atleast twice as fast as the fastest timeout
 #define FEEDING_PERIOD pdMS_TO_TICKS(50)
 
 /* Task timeouts for watchdog */
@@ -108,7 +109,7 @@ void obcTaskFunctionSwWatchdog(void *params) {
 
   // initialize all tasks as checked in
   for (uint8_t i = 0; i < OBC_SCHEDULER_TASK_COUNT; i++) {
-    watchdogTaskArray[i].taskLastCheckInTick = xTaskGetTickCount();
+    digitalWatchdogTaskCheckIn(i);
   }
 
   while (1) {

--- a/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
+++ b/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
@@ -10,7 +10,7 @@
 
 // Must feed the watchdog before the timeout period expires
 // This value should provide some margin
-#define FEEDING_PERIOD pdMS_TO_TICKS(300)
+#define FEEDING_PERIOD pdMS_TO_TICKS(50)
 
 /* Task timeouts for watchdog */
 #define TASK_STATE_MGR_WATCHDOG_TIMEOUT portMAX_DELAY
@@ -105,6 +105,11 @@ void obcTaskFunctionSwWatchdog(void *params) {
   prvRaisePrivilege();
 
   initDigitalWatchdog();
+
+  // initialize all tasks as checked in
+  for (uint8_t i = 0; i < OBC_SCHEDULER_TASK_COUNT; i++) {
+    watchdogTaskArray[i].taskLastCheckInTick = xTaskGetTickCount();
+  }
 
   while (1) {
     bool allTasksCheckedIn = true;


### PR DESCRIPTION
# Purpose
Explain the purpose of the PR here, including references to any existing Notion tasks.
- Currently dig watchdog mgr was initalizing all tasks check-in ticks to 0. UART bl PR added delay to dig watchdog mgr startup which was causing it to startup after the gnc_mgr timeout (100 ticks) had passed. 

Change dig watchdog mgr to initialize all tasks checkin time at startup to the time that it starts up itself

# New Changes
- Explain new changes

# Testing
- Explain tests that you ran to verify code functionality.
- Any functions that can be unit-tested should include a unit test in the PR. Otherwise, explain why it cannot be unit-tested.
- Tested on rev1
# Outstanding Changes
- If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
