### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - uses: denoland/setup-deno@v2
       with:
         deno-version: v2.x

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python_validation.yml
+++ b/.github/workflows/python_validation.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This section will explain how to set up the repo, and how to build, flash, and d
 1. Check if you have Git installed on your system by running `git --version` in a terminal. If it returns some version number, then it's installed. If not, follow the installation steps listed [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). If you're on Windows, it's highly recommended that you also install Git Bash and use that instead of the command prompt or Powershell.
 2. To clone this project, run the following command in whatever directory you want to store the repository in:
 
-```
+```sh
 git clone https://github.com/UWOrbital/OBC-firmware.git
 ```
 
@@ -188,7 +188,7 @@ pre-commit install
 
 From the top-level directory, run the following to build the OBC firmware.
 
-```
+```sh
 mkdir build_arm && cd build_arm
 cmake .. -DCMAKE_BUILD_TYPE=OBC
 cmake --build .
@@ -200,7 +200,7 @@ Take a look at `cmake/fw_build_options.cmake` to see the available build options
 
 From the top-level directory, run the following to build the ground station. Currently, the ground station is only supported on Windows.
 
-```
+```sh
 mkdir build_gs && cd build_gs
 cmake .. -DCMAKE_BUILD_TYPE=GS
 cmake --build .
@@ -217,7 +217,7 @@ sudo apt-get install gcc-multilib g++-multilib
 
 From the top-level directory, run the following to build and run the tests.
 
-```
+```sh
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Test
 cmake --build .
@@ -228,7 +228,7 @@ ctest --verbose
 
 From the top-level directory, run the following to build the example source file.
 
-```
+```sh
 mkdir build_examples && cd build_examples
 cmake .. -DCMAKE_BUILD_TYPE=Examples -DEXAMPLE_TYPE=[EXAMPLE_TO_BE_COMPILED]
 cmake --build .
@@ -255,7 +255,7 @@ Instructions on how to add examples:
 - Add the code and destination above to the list of examples in the form to the `README.md`: `EXAMPLE_ID` - for `example_name`
 - Add the following to the `OBC/CMakeLists.txt` above the comment that says `# ADD MORE EXAMPLES ABOVE THIS COMMENT`
 
-```
+```cmake
 elseif(${EXAMPLE_TYPE} MATCHES EXAMPLE_ID)
 	add_executable(${OUT_FILE_NAME} path_to_main_file_in_example)
 ```

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Skip this section if you set up a Docker development environment.
    sudo apt-get update
    sudo apt-get install build-essential gcc-multilib g++-multilib curl
    ```
-3. Choose the environment where you'll be running `git commit` (either WSL2 or the host) and install Python 3.10 and pip. (Only required for Python devs)
+3. Choose the environment where you'll be running `git commit` (either WSL2 or the host) and install Python 3.11 and pip. (Only required for Backend devs)
    A. If using WSL, follow the instructions under the `Linux` section 2.
 
    B. If you are using Windows. Run the following commands in the OBC-firmware directory:
 
-   Install Python 3.10.12: https://www.python.org/downloads/release/python-31012/
+   Install Python 3.11.11: https://www.python.org/downloads/release/python-31111/
 
    ```sh
    C:\path\to\python\executable -m venv .venv
@@ -131,12 +131,12 @@ brew install make
 brew install gcc
 ```
 
-2. Install Python 3.10 and setup Python virtual environment (Only required for Backend devs)
+2. Install Python 3.11 and setup Python virtual environment (Only required for Backend devs)
 
 Run the following commands in the OBC-firmware directory:
 
 ```sh
-brew install python@3.10
+brew install python@3.11
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -162,13 +162,13 @@ sudo apt-get update
 sudo apt-get install build-essential gcc-multilib g++-multilib curl
 ```
 
-2. Install Python 3.10 and setup Python virtual environment (Only required for Backend devs)
+2. Install Python 3.11 and setup Python virtual environment (Only required for Backend devs)
 
 Run the following commands in the OBC-firmware directory:
 
 ```sh
-sudo apt-get install python3.10
-python3 -m venv .venv
+sudo apt-get install python3.11
+python3.11 -m venv .venv  # You might need to install python3.11-venv using `sudo apt install python3.11-venv` before running this setup
 source .venv/bin/activate
 pip install -r requirements.txt
 pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = [
   "cmake/*",
   "build*",
   "test/*"]
-target-version = "py310"
+target-version = "py311"
 line-length = 120
 indent-width = 4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = OBC/GS
 description = A package for the University of Waterloo Orbital Design Team's Ground Station and On-Board Computer
 author = University of Waterloo Orbital Design Team
 classifiers =
-    Programming Language :: Python :: 3.10 :: Only
+    Programming Language :: Python :: 3.11 :: Only
 
 [options]
 packages =
@@ -12,7 +12,7 @@ packages =
 install_requires =
     requests>=2.31
     pyserial>=3
-python_requires = ~=3.10
+python_requires = ~=3.11
 zip_safe = no
 
 [options.extras_require]


### PR DESCRIPTION
# Purpose
When Python 3.10 was chosen for GS, it was expected that work on the backend would start a lot sooner i.e. S24 when version 3.11 was still in it's bug fix stage. Since, the start of work on the backend was delayed until W25, Python 3.11 is now in stable/security releases. As such it is now considered stable for GS development. 

This PR upgrades the main repo to use 3.11. This version adds new features and improved performance with very little that must be done by GS developers to migrate (See below for Migration instructions). Also, the end of life has been extend by 1 year from Oct 2026 (Python 3.10) to Oct 2027 (Python 3.11).

# Migration Instructions
1. Delete your existing python virtual environment directory used for this repo. Typically the directory is called `.venv` or `venv` 
2. Follow the setup instructions for the backend in the README
- Step 2 of the setup instructions for MacOS and Linux users
- Step 3B of the setup instructions for WSL Windows

# New Changes
- Update README with instructions on how to install Python 3.11
- Update python configuration files to use version 3.11
- Update Github actions to use Python 3.11 where applicable
- Minor README improvements

# Testing
- CI/CD
- Backend starts successfully
![image](https://github.com/user-attachments/assets/4bcb60fc-ed30-443d-8e07-a1d10afc750b)

# Outstanding Changes
- Upgrade Python when 3.11 approaches end of life (good to upgrade around W27 or S27 at the latest) or sooner if desirable 

# Additional Notes
- Upgraded GS onboarding Python 3.11 version with this PR: https://github.com/UWOrbital/GS-Onboarding/pull/12