### PR TITLE
Add logger middleware

### DIFF
--- a/gs/backend/api/backend_setup.py
+++ b/gs/backend/api/backend_setup.py
@@ -30,4 +30,4 @@ def setup_middlewares(app: FastAPI) -> None:
     """Adds the middlewares to the app"""
     add_cors_middleware(app)  # Cors middleware should be added first
     app.add_middleware(AuthMiddleware)
-    app.add_middleware(LoggerMiddleware)
+    app.add_middleware(LoggerMiddleware, excluded_endpoints=[])

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -10,7 +10,10 @@ from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERRO
 
 
 class LoggerMiddleware(BaseHTTPMiddleware):
-    """Middleware that logs the request and response"""
+    """
+    @breif Middleware that logs the request and response
+    @attribute excluded_endpoints (Sequence[str]) - endpoints that won't be logged
+    """
 
     def __init__(self, app: FastAPI, excluded_endpoints: Sequence[str] = ()) -> None:
         super().__init__(app)
@@ -55,9 +58,9 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         has_body_iterator = hasattr(response, "body_iterator")
 
         if has_body_iterator:
-            response_body = b"".join([chunk async for chunk in response.body_iterator])  # type: ignore[attr-defined]
-            response_size = getsizeof(response_body)
-            response_body = response_body.decode(errors="ignore")
+            response_body_bytes = b"".join([chunk async for chunk in response.body_iterator])  # type: ignore[attr-defined]
+            response_size = getsizeof(response_body_bytes)
+            response_body = response_body_bytes.decode(errors="ignore")
         else:
             response_body = "Error logging response body"
             response_size = "Error logging response size"

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -1,7 +1,8 @@
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
 from sys import getsizeof
-from time import time
+from time import perf_counter
+from uuid import uuid4
 
 from fastapi import FastAPI, Request, Response
 from loguru import logger
@@ -22,9 +23,9 @@ class LoggerMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         """Logs the request and response"""
         request_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        start_time = time()
+        start_time = perf_counter()
         response = await call_next(request)
-        process_time = time() - start_time
+        process_time = perf_counter() - start_time
 
         if request.url.path in self.excluded_endpoints:
             return response
@@ -34,16 +35,18 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         # TODO: update this based on userID header name
         request_user_id = request.headers.get("user_id", "Anonymous")
         request_params = dict(request.query_params)
+        request_id = str(uuid4())
 
         logger.info(
             " | ".join(
                 [
                     f"REQUEST | Method: {request.method}",
+                    f"Request ID: {request_id}",
                     f"URL: {request.url.path}",
                     f"User id: {request_user_id}",
                     f"Params: {request_params}",
                     f"Time: {request_time}",
-                    f"Size: {request_size} bytes.",
+                    f"Bytes: {request_size}.",
                 ]
             )
         )
@@ -55,6 +58,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         else:
             logger_severity = logger.info
 
+        # not all responses have a body_iterator attribute
         has_body_iterator = hasattr(response, "body_iterator")
 
         if has_body_iterator:
@@ -69,9 +73,10 @@ class LoggerMiddleware(BaseHTTPMiddleware):
             " | ".join(
                 [
                     f"RESPONSE | Status: {response.status_code}",
+                    f"Request ID: {request_id}",
                     f"Response: {response_body}",
-                    f"Size (bytes): {response_size}",
-                    f"Time Elasped: {process_time:.3f} seconds.",
+                    f"Bytes: {response_size}",
+                    f"Seconds Elasped: {process_time:.3f}.",
                 ]
             )
         )
@@ -83,5 +88,4 @@ class LoggerMiddleware(BaseHTTPMiddleware):
                 headers=dict(response.headers),
                 media_type=response.media_type,
             )
-        else:
-            return response
+        return response

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -21,10 +21,10 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         request_body = await request.body()
         request_size = getsizeof(request_body)
         # TODO: update this based on userID header name
-        request_userID = request.headers.get("userID", "Anonymous")
+        request_user_id = request.headers.get("user_id", "Anonymous")
         request_params = dict(request.query_params)
 
-        logger.info(f"REQUEST | Method: {request.method} | URL: {request.url.path} | User id: {request_userID} | Params: {request_params} | Size: {request_size} bytes.")
+        logger.info(f"REQUEST | Method: {request.method} | URL: {request.url.path} | User id: {request_user_id} | Params: {request_params} | Size: {request_size} bytes.")
         
         if response.status_code >= 500:
             logger_severity = logger.critical

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -1,47 +1,77 @@
-from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from loguru import logger
-from time import time
+from collections.abc import Sequence
+from datetime import datetime
 from sys import getsizeof
-from typing import List
+from time import time
+from typing import Final
 
-#add any endpoints we don't want logged here, e.g "/example/endpoint"
-excluded_endpoints: List[str] = []
+from fastapi import FastAPI, Request, Response
+from loguru import logger
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+
 class LoggerMiddleware(BaseHTTPMiddleware):
     """Middleware that logs the request and response"""
 
+    def __init__(self, app: FastAPI, excluded_endpoints: Sequence[str] = ()) -> None:
+        super().__init__(app)
+        self.excluded_endpoints = excluded_endpoints
+
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Logs the request and response"""
+        request_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         start_time = time()
         response = await call_next(request)
         process_time = time() - start_time
-        
-        if request.url.path in excluded_endpoints:
+
+        if request.url.path in self.excluded_endpoints:
             return response
-        
+
         request_body = await request.body()
         request_size = getsizeof(request_body)
         # TODO: update this based on userID header name
         request_user_id = request.headers.get("user_id", "Anonymous")
         request_params = dict(request.query_params)
 
-        logger.info(f"REQUEST | Method: {request.method} | URL: {request.url.path} | User id: {request_user_id} | Params: {request_params} | Size: {request_size} bytes.")
-        
-        if response.status_code >= 500:
+        logger.info(
+            " | ".join(
+                [
+                    f"REQUEST | Method: {request.method}",
+                    f"URL: {request.url.path}",
+                    f"User id: {request_user_id}",
+                    f"Params: {request_params}",
+                    f"Time: {request_time}",
+                    f"Size: {request_size} bytes.",
+                ]
+            )
+        )
+
+        http_status_code_error_server: Final[int] = 500
+        http_status_code_error: Final[int] = 400
+
+        if response.status_code >= http_status_code_error_server:
             logger_severity = logger.critical
-        elif response.status_code >= 400:
+        elif response.status_code >= http_status_code_error:
             logger_severity = logger.error
         else:
             logger_severity = logger.info
-        
-        response_body = b''.join([chunk async for chunk in response.body_iterator])
+
+        response_body = b"".join([chunk async for chunk in response.body_iterator])
         response_size = getsizeof(response_body)
-        
-        logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors='ignore')} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
-        
+
+        logger_severity(
+            " | ".join(
+                [
+                    f"RESPONSE | Status: {response.status_code}",
+                    f"Response: {response_body.decode(errors='ignore')}",
+                    f"Size: {response_size} bytes",
+                    f"Time Elasped: {process_time:.3f}.",
+                ]
+            )
+        )
+
         return Response(
-            content=response_body, 
-            status_code=response.status_code, 
-            headers=dict(response.headers), 
+            content=response_body,
+            status_code=response.status_code,
+            headers=dict(response.headers),
             media_type=response.media_type,
         )
-    

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -36,7 +36,6 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         response_body = b''.join([chunk async for chunk in response.body_iterator])
         response_size = getsizeof(response_body)
         
-
         logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors='ignore')} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
         
         return Response(
@@ -45,3 +44,4 @@ class LoggerMiddleware(BaseHTTPMiddleware):
             headers=dict(response.headers), 
             media_type=response.media_type,
         )
+    

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -33,9 +33,9 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         else:
             logger_severity = logger.info
         
-        chunks = [chunk async for chunk in response.body_iterator]
-        response_body = b''.join(chunks)
+        response_body = b''.join([chunk async for chunk in response.body_iterator])
         response_size = getsizeof(response_body)
+        
 
         logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors='ignore')} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
         
@@ -44,5 +44,4 @@ class LoggerMiddleware(BaseHTTPMiddleware):
             status_code=response.status_code, 
             headers=dict(response.headers), 
             media_type=response.media_type,
-            body_iterator=chunks
         )

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -59,7 +59,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
 
         if has_body_iterator:
             response_body_bytes = b"".join([chunk async for chunk in response.body_iterator])  # type: ignore[attr-defined]
-            response_size = getsizeof(response_body_bytes)
+            response_size = str(getsizeof(response_body_bytes))
             response_body = response_body_bytes.decode(errors="ignore")
         else:
             response_body = "Error logging response body"

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -1,12 +1,45 @@
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from loguru import logger
+from time import time
+from sys import getsizeof
 
-
+#add any endpoints we don't want logged here, e.g "/example/endpoint"
+excluded_endpoints = []
 class LoggerMiddleware(BaseHTTPMiddleware):
     """Middleware that logs the request and response"""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        """Logs the request and response"""
-        # TODO: Add logging here
+        start_time = time()
         response = await call_next(request)
-        return response
+        process_time = time() - start_time
+        
+        if request.url.path in excluded_endpoints:
+            return response
+        
+        request_body = await request.body()
+        request_size = getsizeof(request_body)
+        # TODO: update this based on userID header name
+        request_userID = request.headers.get("userID", "Anonymous")
+        request_params = dict(request.query_params)
+
+        logger.info(f"REQUEST | Method: {request.method} | URL: {request.url.path} | User id: {request_userID} | Params: {request_params} | Size: {request_size} bytes.")
+        
+        if response.status_code >= 500:
+            logger_severity = logger.critical
+        elif response.status_code >= 400:
+            logger_severity = logger.error
+        else:
+            logger_severity = logger.info
+        
+        response_body = b''.join([chunk async for chunk in response.body_iterator])
+        response_size = getsizeof(response_body)
+
+        logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors="ignore")} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
+        
+        return Response(
+            content=response_body, 
+            status_code=response.status_code, 
+            headers=dict(response.headers), 
+            media_type=response.media_type
+        )

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -55,10 +55,9 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         has_body_iterator = hasattr(response, "body_iterator")
 
         if has_body_iterator:
-            response_body = b"".join([chunk async for chunk in response.body_iterator])
-            # type: ignore[attr-defined]
+            response_body = b"".join([chunk async for chunk in response.body_iterator])  # type: ignore[attr-defined]
+            response_size = getsizeof(response_body)
             response_body = response_body.decode(errors="ignore")
-            response_size = str(getsizeof(response_body)) + " bytes"
         else:
             response_body = "Error logging response body"
             response_size = "Error logging response size"
@@ -68,7 +67,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
                 [
                     f"RESPONSE | Status: {response.status_code}",
                     f"Response: {response_body}",
-                    f"Size: {response_size}",
+                    f"Size (bytes): {response_size}",
                     f"Time Elasped: {process_time:.3f} seconds.",
                 ]
             )

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -18,7 +18,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
 
     def add_excluded_endpoints(self, excluded_endpoints: Sequence[str]) -> None:
         """Adds an endpoint to the non-logging list"""
-        self.excluded_endpoints.add(excluded_endpoints)
+        self.excluded_endpoints.extend(excluded_endpoints)
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         """Logs the request and response"""
@@ -59,7 +59,9 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         else:
             logger_severity = logger.info
 
-        if getattr(response, "body_iterator", None):
+        is_a_streaming_response = hasattr(response, "body_iterator")
+
+        if is_a_streaming_response:
             response_body = b"".join([chunk async for chunk in response.body_iterator])
         else:
             response_body = await response.body()

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -35,7 +35,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         response_body = b''.join([chunk async for chunk in response.body_iterator])
         response_size = getsizeof(response_body)
 
-        logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors="ignore")} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
+        logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors='ignore')} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
         
         return Response(
             content=response_body, 

--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -3,9 +3,10 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from loguru import logger
 from time import time
 from sys import getsizeof
+from typing import List
 
 #add any endpoints we don't want logged here, e.g "/example/endpoint"
-excluded_endpoints = []
+excluded_endpoints: List[str] = []
 class LoggerMiddleware(BaseHTTPMiddleware):
     """Middleware that logs the request and response"""
 
@@ -32,7 +33,8 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         else:
             logger_severity = logger.info
         
-        response_body = b''.join([chunk async for chunk in response.body_iterator])
+        chunks = [chunk async for chunk in response.body_iterator]
+        response_body = b''.join(chunks)
         response_size = getsizeof(response_body)
 
         logger_severity(f"RESPONSE | Status: {response.status_code} | Response: {response_body.decode(errors='ignore')} | Size: {response_size} bytes | Time Elasped: {process_time:.3f}.")
@@ -41,5 +43,6 @@ class LoggerMiddleware(BaseHTTPMiddleware):
             content=response_body, 
             status_code=response.status_code, 
             headers=dict(response.headers), 
-            media_type=response.media_type
+            media_type=response.media_type,
+            body_iterator=chunks
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyserial==3.5
 skyfield==1.48
 fastapi[standard]==0.115.0
 sqlmodel==0.0.22
+loguru==0.7.3
 
 # Typed packages
 types-requests==2.31.0


### PR DESCRIPTION
# Purpose
Closes #369 

# New Changes
 - Any incoming requests and their responses can now be logged via the logger-middleware
 - The logged information includes: Time of request, request method, request url, request size, request params, response status (error severity if applicable), response body, response size, and process time.
 - Endpoints that we don't want logged can now be passed to the middleware via backend_setup.py 
 - Added loguru to requirements.txt

# Testing
- I didn't want to pollute the code with the fake endpoint, so here is the code if you want to test this. Add this code to gs/backend/api/v1/mcc/endpoints/commands.py.
```python
from fastapi import APIRouter, HTTPException

commands_router = APIRouter(tags=["MCC", "Commands"])


@commands_router.get("/double")
def double(data: str):
    return {"data": f"{data} {data}"}
```

running the endpoint /api/v1/mcc/commands/double?input=hello world! should return {"data": "hello world! hello world!"}

Normal:
![log_success](https://github.com/user-attachments/assets/150a8a57-5c62-4500-92f9-bf41aa800bb9)

Error:
![log_error](https://github.com/user-attachments/assets/22314636-78d8-40a5-8cb8-75547ac418ff)

Critical Error:
![log_critical](https://github.com/user-attachments/assets/c8289213-d649-4f9e-ab7f-1733e7c1622e)

# Outstanding Changes
- Implement logging the userid. The current logic checks the request headers for "user_id", and sets it to anonymous if not found.

