### PR TITLE
Fix logger middleware causing 500 error if request has body workaround

### DIFF
--- a/gs/backend/api/middleware/logger_middleware.py
+++ b/gs/backend/api/middleware/logger_middleware.py
@@ -30,8 +30,10 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         if request.url.path in self.excluded_endpoints:
             return response
 
-        request_body = await request.body()
-        request_size = getsizeof(request_body)
+        # TODO: This causes a runtime error of `Stream Consumed` when making a request with a body
+        # request_body = await request.body()
+        # request_size = getsizeof(request_body)
+
         # TODO: update this based on userID header name
         request_user_id = request.headers.get("user_id", "Anonymous")
         request_params = dict(request.query_params)
@@ -46,7 +48,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
                     f"User id: {request_user_id}",
                     f"Params: {request_params}",
                     f"Time: {request_time}",
-                    f"Bytes: {request_size}.",
+                    # f"Bytes: {request_size}.",
                 ]
             )
         )


### PR DESCRIPTION
# Purpose
Closes #391. This PR is intended to be a workaround to the issue. We still should be logging the request body.

# New Changes
- Uncomment the lines causing the issue

# Testing
- I've tested that these exact changes fix the crash described in the linked issue by making the same changes on `361-create-endpoints-for-aro-user`

# Outstanding Changes
- Make the logger middleware log the request body
- Make the logger middleware log the request information before the `call_next` line
