### PR TITLE
Add sectionVersion to headers

### DIFF
--- a/obc/app/sys/persistent/obc_persistent.c
+++ b/obc/app/sys/persistent/obc_persistent.c
@@ -12,10 +12,12 @@
 static const obc_persist_config_t obcPersistConfig[] = {
     [OBC_PERSIST_SECTION_ID_OBC_TIME] = {.sectionStartAddr = OBC_PERSIST_ADDR_OF(obcTime),
                                          .sectionSize = sizeof(obc_time_persist_t),
+                                         .sectionVersion = OBC_PERSISTENT_VERSION,
                                          .dataSize = sizeof(obc_time_persist_data_t),
                                          .sectionCount = OBC_PERSISTENT_MIN_SUBINDEX},
     [OBC_PERSIST_SECTION_ID_ALARM_MGR] = {.sectionStartAddr = OBC_PERSIST_ADDR_OF(alarmMgr),
                                           .sectionSize = sizeof(alarm_mgr_persist_t),
+                                          .sectionVersion = OBC_PERSISTENT_VERSION,
                                           .dataSize = sizeof(alarm_mgr_persist_data_t),
                                           .sectionCount = OBC_PERSISTENT_MAX_SUBINDEX_ALARM},
 };
@@ -110,6 +112,7 @@ obc_error_code_t setPersistentDataByIndex(obc_persist_section_id_t sectionId, si
   // Create header
   obc_persist_section_header_t header = {0};
   header.sectionSize = config->sectionSize;
+  header.sectionVersion = config->sectionVersion;
   // Use the dataSize as that's what we're writing
   header.crc32 = computeCrc32(0, buffPtr, config->dataSize);
 

--- a/obc/app/sys/persistent/obc_persistent.h
+++ b/obc/app/sys/persistent/obc_persistent.h
@@ -35,6 +35,8 @@
  *       OBC_PERSIST_ADDR_OF macro with the section name (e.g. OBC_PERSIST_ADDR_OF(obcTime))
  *     - The sectionSize should be the size of the section in FRAM, use the sizeof() macro
  *       with the section struct name (e.g. sizeof(obc_time_persist_t))
+ *     - The sectionVersion should be the current version number of obc_persist, defined by 
+ *       the macro OBC_PERSISTENT_VERSION
  *     - The dataSize should be the size of the data in the section, use the sizeof() macro
  *       with the data struct name (e.g. sizeof(obc_time_persist_data_t)). This is used to
  *       verify that the buffer passed to the get/set functions is large enough.
@@ -52,6 +54,9 @@ extern "C" {
 #define OBC_PERSISTENT_MIN_SUBINDEX 1U
 #define OBC_PERSISTENT_MAX_SUBINDEX_ALARM 24U
 
+/* Current version of obc_persistent to store in section headers */
+#define OBC_PERSISTENT_VERSION 1
+
 /*---------------------------------------------------------------------------*/
 /**
  * @brief Header struct to be placed at the start of each persistent section
@@ -59,6 +64,7 @@ extern "C" {
  */
 typedef struct {
   uint32_t sectionSize;
+  uint32_t sectionVersion;
   uint32_t crc32;
 } obc_persist_section_header_t;
 
@@ -160,6 +166,7 @@ typedef enum {
 typedef struct {
   size_t sectionStartAddr;  // Includes the header
   size_t sectionSize;       // Includes the header
+  uint32_t sectionVersion;
   size_t dataSize;          // Size of the data in the section (Does not include the header)
   size_t sectionCount;
 } obc_persist_config_t;


### PR DESCRIPTION
# Purpose

# New Changes
- added sectionVersion to obc_persist_config_t type
- added sectionVersion to obc_persist_section_header_t type
- defined OBC_PERSISTENT_VERSION macro, to be set on header creation

# Testing

# Outstanding Changes
