### PR TITLE
Bootloader Timer

### DIFF
--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -22,9 +22,7 @@ extern uint32_t __ramFuncsRunEnd__;
 #define BL_MAX_MSG_SIZE 64U
 #define RM46_FLASH_BANK 0U
 #define LAST_SECTOR_START_ADDR blFlashSectorStartAddr(15U)
-#define WAIT_FOREVER \
-  4000000000  // A very large number to pass as an argument to wait forever when using
-              // blUartReadBytes()
+#define WAIT_FOREVER UINT32_MAX
 
 /* TYPEDEFS */
 typedef void (*appStartFunc_t)(void);
@@ -57,7 +55,7 @@ int main(void) {
         blUartWriteBytes(strlen("Waiting for input\r\n"), (uint8_t *)"Waiting for input\r\n");
 
         char c = '\0';
-        blUartReadBytes((uint8_t *)&c, 1, 1000);
+        blUartReadBytes((uint8_t *)&c, 1, 10000);
 
         if (c == 'd') {
           state = BL_STATE_DOWNLOAD_IMAGE;

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -2,6 +2,7 @@
 #include "bl_flash.h"
 #include "bl_uart.h"
 #include "bl_errors.h"
+#include "rti.h"
 #include <metadata_struct.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -40,6 +41,8 @@ int main(void) {
   bl_error_code_t errCode = BL_ERR_CODE_SUCCESS;
 
   blUartInit();
+  rtiInit();
+  rtiStartCounter(rtiCOUNTER_BLOCK1);
 
   // F021 API and the functions that use it must be executed from RAM since they
   // can't execute from the same flash bank being modified
@@ -62,7 +65,7 @@ int main(void) {
           state = BL_STATE_ERASE_IMAGE;
         } else if (c == 'r' || c == '\0') {
           state = BL_STATE_RUN_APP;
-          blUartWriteBytes(1, (uint8_t *)"A");
+          blUartWriteBytes(strlen("Jumping to app location\r\n"), (uint8_t *)"Jumping to app location\r\n");
         }
         break;
       }

--- a/obc/bl/include/bl_uart.h
+++ b/obc/bl/include/bl_uart.h
@@ -10,13 +10,14 @@
 void blUartInit(void);
 
 /**
- * @brief Read a stream of bytes from the UART
+ * @brief Read a stream of bytes from the UART.
  *
  * @param uartReg UART register to read from
  * @param buf Buffer to read into
+ * @param timeout The timeout for the function to wait to receive bytes.
  * @param numBytes Number of bytes to read
  */
-void blUartReadBytes(uint8_t *buf, uint32_t numBytes);
+void blUartReadBytes(uint8_t *buf, uint32_t numBytes, uint32_t timeout_ms);
 
 /**
  * @brief Write a stream of bytes to the UART

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -30,7 +30,8 @@ void blUartReadBytes(uint8_t *buf, uint32_t numBytes, uint32_t timeout_ms) {
         buf[i] = (uint8_t)sciReceiveByte(UART_BL_REG);
       }
     }
-  } while (((rtiGetCurrentTick(rtiCOMPARE1) - initTime) / 50) < timeout_ms);
+  } while (((rtiGetCurrentTick(rtiCOMPARE1) - initTime) / 50) < timeout_ms ||
+           rtiGetCurrentTick(rtiCOMPARE1) < initTime);
 }
 
 void blUartWriteBytes(uint32_t numBytes, uint8_t *buf) { sciSend(UART_BL_REG, numBytes, buf); }

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -20,9 +20,6 @@ void blUartInit(void) {
   sciInit();
 
   sciSetBaudrate(UART_BL_REG, BL_UART_SCIREG_BAUD);
-
-  rtiInit();
-  rtiStartCounter(rtiCOUNTER_BLOCK1);
 }
 
 void blUartReadBytes(uint8_t *buf, uint32_t numBytes, uint32_t timeout_ms) {
@@ -33,7 +30,7 @@ void blUartReadBytes(uint8_t *buf, uint32_t numBytes, uint32_t timeout_ms) {
         buf[i] = (uint8_t)sciReceiveByte(UART_BL_REG);
       }
     }
-  } while ((rtiGetCurrentTick(rtiCOMPARE1) - initTime) < (timeout_ms * 50));
+  } while (((rtiGetCurrentTick(rtiCOMPARE1) - initTime) / 50) < timeout_ms);
 }
 
 void blUartWriteBytes(uint32_t numBytes, uint8_t *buf) { sciSend(UART_BL_REG, numBytes, buf); }

--- a/obc/shared/hal/common/rti_weak.c
+++ b/obc/shared/hal/common/rti_weak.c
@@ -18,6 +18,10 @@ uint32_t rtiGetCounterOneTick() {
   return rtiBase->CNT[1].FRCx; 
 }
 
+uint32 rtiGetCurrentTick(uint32 compare) {
+    return rtiBase->CNT[1].FRCx;
+}
+
 /**
  * @brief Resets all of RTI Counter 1. Disables the counter until enabled again 
  * using rtiStartCounter.

--- a/obc/tools/python/bl_test.py
+++ b/obc/tools/python/bl_test.py
@@ -18,6 +18,6 @@ if __name__ == "__main__":
         print("Receiving from bootloader...")
         print(ser.read(len("Waiting for input\r\n")))
         start = time.time()
-        print(ser.read(1))
+        print(ser.read(len("Jumping to app location\r\n")))
         end = time.time()
         print(end - start)

--- a/obc/tools/python/bl_test.py
+++ b/obc/tools/python/bl_test.py
@@ -1,0 +1,23 @@
+import time
+from typing import Final
+
+from serial import PARITY_NONE, STOPBITS_TWO, Serial
+
+# TEST SCRIPT TO WRITE TO BL
+
+OBC_UART_BAUD_RATE: Final[int] = 115200
+
+if __name__ == "__main__":
+    with Serial(
+        "/dev/ttyACM0",
+        baudrate=OBC_UART_BAUD_RATE,
+        parity=PARITY_NONE,
+        stopbits=STOPBITS_TWO,
+        timeout=5,
+    ) as ser:
+        print("Receiving from bootloader...")
+        print(ser.read(len("Waiting for input\r\n")))
+        start = time.time()
+        print(ser.read(1))
+        end = time.time()
+        print(end - start)

--- a/obc/tools/python/bl_test.py
+++ b/obc/tools/python/bl_test.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         baudrate=OBC_UART_BAUD_RATE,
         parity=PARITY_NONE,
         stopbits=STOPBITS_TWO,
-        timeout=5,
+        timeout=20,
     ) as ser:
         print("Receiving from bootloader...")
         print(ser.read(len("Waiting for input\r\n")))


### PR DESCRIPTION
# Purpose
Currently the boot loader gets stuck during resets as it keeps waiting on the character `r` to be sent via UART. This PR implements a timeout that starts the program after a certain number of milliseconds (currently set to `1000 milliseconds`)

# New Changes
- Defined a new `rtiGetCurrentTick()` function (NOTE: This does not use compares)
- Added a timeout to `blUartReadBytes()`
- Added testing code with `bl_test.py` and some uart sends in `bl_main.c` (NEED TO BE REMOVED BEFORE MERGE)

# Testing
- Created a python script that times how long the timeout lasts before the program starts. Essentially this first receives the `"Waiting for input\r\n"`, starts a timer, then stops it when it receives the `"A"` character which denotes the bootloader changed state successfully. The number printed is the time in seconds.
![image](https://github.com/user-attachments/assets/db7ab6ec-313c-454d-8143-14c7acd7b15f)

# Outstanding Changes
 - Need to verify the scaling factor used to convert milliseconds to ticks in the `do {} while()` loop in `bl_uart.c`
