### PR TITLE
Initial commit with standardize reset command and implementation on b…

### DIFF
--- a/interfaces/obc_gs_interface/commands/__init__.py
+++ b/interfaces/obc_gs_interface/commands/__init__.py
@@ -178,8 +178,7 @@ class CmdCallbackId(IntEnum):
     CMD_ERASE_APP = 9
     CMD_DOWNLOAD_DATA = 10
     CMD_VERIFY_CRC = 11
-    CMD_RESET_BL = 12
-    NUM_CMD_CALLBACKS = 13
+    NUM_CMD_CALLBACKS = 12
 
 
 # Path to File: interfaces/obc_gs_interface/commands/obc_gs_commands_response.h
@@ -396,20 +395,6 @@ def create_cmd_verify_crc(unixtime_of_execution: int | None = None) -> CmdMsg:
     """
     cmd_msg = CmdMsg(unixtime_of_execution)
     cmd_msg.id = CmdCallbackId.CMD_VERIFY_CRC
-    return cmd_msg
-
-
-def create_cmd_reset_bl(unixtime_of_execution: int | None = None) -> CmdMsg:
-    """
-    Function to create a CmdMsg structure for CMD_RESET_BL
-
-    :param unixtime_of_execution: A time of when to execute a certain event,
-                                  by default, it is set to None (i.e. a specific
-                                  time is not needed)
-    :return: CmdMsg structure for CMD_RESET_BL
-    """
-    cmd_msg = CmdMsg(unixtime_of_execution)
-    cmd_msg.id = CmdCallbackId.CMD_RESET_BL
     return cmd_msg
 
 

--- a/interfaces/obc_gs_interface/commands/obc_gs_command_id.h
+++ b/interfaces/obc_gs_interface/commands/obc_gs_command_id.h
@@ -48,6 +48,5 @@ typedef enum {
   CMD_ERASE_APP,
   CMD_DOWNLOAD_DATA,
   CMD_VERIFY_CRC,
-  CMD_RESET_BL,
   NUM_CMD_CALLBACKS
 } cmd_callback_id_t;

--- a/interfaces/obc_gs_interface/commands/obc_gs_command_pack.c
+++ b/interfaces/obc_gs_interface/commands/obc_gs_command_pack.c
@@ -43,9 +43,6 @@ static void packEraseAppCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg
 // CMD_VERIFY_CRC
 static void packVerifyCrcCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg_t* msg);
 
-// CMD_RESET_BL
-static void packResetBlCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg_t* msg);
-
 typedef void (*pack_func_t)(uint8_t*, uint32_t*, const cmd_msg_t*);
 
 static const pack_func_t packFns[] = {
@@ -60,7 +57,6 @@ static const pack_func_t packFns[] = {
     [CMD_DOWNLOAD_DATA] = packDownloadDataCmdData,
     [CMD_ERASE_APP] = packEraseAppCmdData,
     [CMD_VERIFY_CRC] = packVerifyCrcCmdData,
-    [CMD_RESET_BL] = packResetBlCmdData,
     // Add more functions for other commands as needed
 };
 
@@ -146,10 +142,5 @@ static void packEraseAppCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg
 
 // CMD_VERIFY_CRC
 static void packVerifyCrcCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg_t* cmdMsg) {
-  // No data to pack
-}
-
-// CMD_RESET_BL
-static void packResetBlCmdData(uint8_t* buffer, uint32_t* offset, const cmd_msg_t* msg) {
   // No data to pack
 }

--- a/interfaces/obc_gs_interface/commands/obc_gs_command_unpack.c
+++ b/interfaces/obc_gs_interface/commands/obc_gs_command_unpack.c
@@ -46,9 +46,6 @@ static void unpackEraseAppCmdData(const uint8_t* buffer, uint32_t* offset, cmd_m
 // CMD_VERIFY_CRC
 static void unpackVerifyCrcCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* msg);
 
-// CMD_RESET_BL
-static void unpackResetBlCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* msg);
-
 typedef void (*unpack_func_t)(const uint8_t*, uint32_t*, cmd_msg_t*);
 
 static const unpack_func_t unpackFns[] = {
@@ -63,7 +60,6 @@ static const unpack_func_t unpackFns[] = {
     [CMD_DOWNLOAD_DATA] = unpackDownloadDataCmdData,
     [CMD_ERASE_APP] = unpackEraseAppCmdData,
     [CMD_VERIFY_CRC] = unpackVerifyCrcCmdData,
-    [CMD_RESET_BL] = unpackResetBlCmdData,
     // Add more functions for other commands as needed
 };
 
@@ -158,10 +154,5 @@ static void unpackEraseAppCmdData(const uint8_t* buffer, uint32_t* offset, cmd_m
 
 // CMD_VERIFY_CRC
 static void unpackVerifyCrcCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* cmdMsg) {
-  // No data to unpack
-}
-
-// CMD_RESET_BL
-static void unpackResetBlCmdData(const uint8_t* buffer, uint32_t* offset, cmd_msg_t* cmdMsg) {
   // No data to unpack
 }

--- a/obc/bl/source/bl_command_callbacks.c
+++ b/obc/bl/source/bl_command_callbacks.c
@@ -1,3 +1,4 @@
+#include "reg_system.h"
 #include "bl_errors.h"
 #include "bl_config.h"
 #include "obc_errors.h"
@@ -13,6 +14,7 @@
 
 #define BL_BIN_RX_CHUNK_SIZE 208U  // Bytes
 #define MAX_PACKET_SIZE 223
+#define RESET_SYSTEM_MASK (1 << 15)
 
 programming_session_t programmingSession = APPLICATION;
 extern uint32_t __APP_IMAGE_TOTAL_SECTION_SIZE;
@@ -110,23 +112,27 @@ static obc_error_code_t verifyCrcCmdCallback(cmd_msg_t *cmd) {
   return OBC_ERR_CODE_SUCCESS;
 }
 
-static obc_error_code_t resetBlCmdCallback(cmd_msg_t *cmd) {
+static obc_error_code_t execObcResetCmdCallback(cmd_msg_t *cmd) {
   if (cmd == NULL) {
     return OBC_ERR_CODE_INVALID_ARG;
   }
 
   // TODO: Implement OBC reset functionality
+  blUartWriteBytes(strlen("Resetting System \r\n"), (uint8_t *)"Resetting System \r\n");
+  systemREG1->SYSECR |= RESET_SYSTEM_MASK;
+  while (1) {
+  }
 
   return OBC_ERR_CODE_SUCCESS;
 }
 
 const cmd_info_t cmdsConfig[] = {
+    [CMD_EXEC_OBC_RESET] = {execObcResetCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_PING] = {pingCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_SET_PROGRAMMING_SESSION] = {setProgrammingSessionCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_ERASE_APP] = {eraseAppCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_DOWNLOAD_DATA] = {downloadDataCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_VERIFY_CRC] = {verifyCrcCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
-    [CMD_RESET_BL] = {resetBlCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
 };
 
 // This function is purely to trick the compiler into thinking we are using the cmdsConfig variable so we avoid the

--- a/obc/tools/python/app_update.py
+++ b/obc/tools/python/app_update.py
@@ -12,6 +12,7 @@ from interfaces.obc_gs_interface.commands import (
     ProgrammingSession,
     create_cmd_download_data,
     create_cmd_erase_app,
+    create_cmd_exec_obc_reset,
     pack_command,
 )
 
@@ -96,6 +97,12 @@ def send_bin(file_path: str, com_port: str) -> None:
         ser.read(len("Received packet\r\nWrite success\r\n"))
         progress_bar.update(1)
         progress_bar.close()
+        reset_command = pack_command(create_cmd_exec_obc_reset())
+        print("Reset App")
+        print(reset_command)
+        ser.write(reset_command.ljust(RS_DECODED_DATA_SIZE, b"\x00"))
+        print(ser.read(100))
+        sleep(0.1)
 
 
 def main() -> None:
@@ -118,6 +125,8 @@ def main() -> None:
 
         print("Starting Flashing Procedure...")
         send_bin(str(path), com_port)
+        sleep(5)
+
     except SerialException:
         print("Invalid port entered")
 


### PR DESCRIPTION
…ootloader side

# Purpose
Closes #526.
Standardize the reset command between the bootloader and app. Moreover, reset functionality on the bootloader side is implemented.

# New Changes
- Remove `CMD_RESET_BL`
- Add `CMD_EXEC_OBC_RESET` functionality to bootloader side.

# Testing
Explain tests that you ran to verify code functionality.
- [ ] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [ ] I have tested this PR on a board if the code will run on a board (Only required for firmware developers).
- [ ] I have tested this PR by running the ARO website (Only required if the code will impact the ARO website).
- [ ] I have tested this PR by running the MCC website (Only required if the code will impact the MCC website).
- [ ] I have included screenshots of the tests performed below.

# Outstanding Changes
If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
