### PR TITLE
Changed SQLAlchemy to use loguru logger with custom level(VERBOSE)

### DIFF
--- a/gs/backend/api/backend_setup.py
+++ b/gs/backend/api/backend_setup.py
@@ -1,4 +1,7 @@
+import logging
+
 from fastapi import FastAPI
+from loguru import logger
 
 from gs.backend.api.middleware.auth_middleware import AuthMiddleware
 from gs.backend.api.middleware.cors_middleware import add_cors_middleware
@@ -33,3 +36,18 @@ def setup_middlewares(app: FastAPI) -> None:
     add_cors_middleware(app)  # Cors middleware should be added first
     app.add_middleware(AuthMiddleware)
     app.add_middleware(LoggerMiddleware, excluded_endpoints=[])
+
+
+def setup_logging() -> None:
+    """Sets all logs from SQLAlchemy to the custom logger level VERBOSE"""
+    verbose_level = 15  # DEBUG=10, INFO=20
+    logger.level("VERBOSE", no=verbose_level, color="<blue>")
+
+    class SQLAlchemyHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            logger.log("VERBOSE", record.getMessage())
+
+    sqlalchemy_logger = logging.getLogger("sqlalchemy.engine")
+    sqlalchemy_logger.setLevel(logging.INFO)
+    sqlalchemy_logger.addHandler(SQLAlchemyHandler())
+    sqlalchemy_logger.propagate = False

--- a/gs/backend/data/database/engine.py
+++ b/gs/backend/data/database/engine.py
@@ -13,8 +13,7 @@ def get_db_engine() -> Engine:
 
     :return: engine
     """
-    # TODO: Add loguru to sqlalchemy.engine logger
-    return create_engine(DATABASE_CONNECTION_STRING, echo=True)
+    return create_engine(DATABASE_CONNECTION_STRING)
 
 
 def get_db_session() -> Session:

--- a/gs/backend/main.py
+++ b/gs/backend/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
 
-from gs.backend.api.backend_setup import setup_middlewares, setup_routes
+from gs.backend.api.backend_setup import setup_logging, setup_middlewares, setup_routes
 from gs.backend.api.lifespan import lifespan
 
 app = FastAPI(lifespan=lifespan)
+setup_logging()
 setup_routes(app)
 setup_middlewares(app)


### PR DESCRIPTION
# Purpose
Closes #380 .
Make SQLAlchemy use loguru so that logs are in the same place as middleware.

# New Changes
Explain new changes below in short bullet points.
Creates a custom logging level with loguru called "VERBOSE"
Adds a handler to reroute all logs from SQLAlchemy to use the "VERBOSE" level.

# Testing
- [x] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
Ran basic SQL queries and captured the logs.
- [x] I have included screenshots of the tests performed below.
<img width="1064" height="226" alt="Screenshot 2025-09-23 at 12 03 13 AM" src="https://github.com/user-attachments/assets/a10eab10-2d4c-4d8c-88d9-8c0bfcc88546" />

# Outstanding Changes
If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
Currently, the verbosity level is INFO, but you can increase or decrease this to change the amount of detail in the logs.
Because of the handler that logs messages with the custom VERBOSE level, the stack trace always prints the same line(the log within the handler). I believe there is a way to print the original stack trace instead.