### PR TITLE
Attempt to resolve issue #349

### DIFF
--- a/gs/backend/api/v1/mcc/endpoints/aro_requests.py
+++ b/gs/backend/api/v1/mcc/endpoints/aro_requests.py
@@ -1,3 +1,25 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
+
+from gs.backend.api.v1.mcc.models.responses import ARORequestsResponse
+from gs.backend.data.data_wrappers.wrappers import ARORequestWrapper
+from gs.backend.data.enums.aro_requests import ARORequestStatus
 
 aro_requests_router = APIRouter(tags=["MCC", "ARO Requests"])
+
+
+@aro_requests_router.get("/", response_model=ARORequestsResponse)
+async def get_aro_requests(
+    count: int = 100,
+    offset: int = 0,
+    filters: list[ARORequestStatus] | None = Query(default=None),
+) -> ARORequestsResponse:
+    """
+    Retrieve ARO requests.
+
+    :param count: Number of most recent requests to return. If <= 0, all requests are returned.
+    :param offset: Starting index in descending request order (for paging).
+    :param filters: List of statuses to filter by. If empty, no filtering is applied.
+    :return: ARO requests matching the criteria.
+    """
+    requests = ARORequestWrapper().get_requests(count=count, offset=offset, filters=filters)
+    return ARORequestsResponse(data=requests)

--- a/gs/backend/api/v1/mcc/models/responses.py
+++ b/gs/backend/api/v1/mcc/models/responses.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from gs.backend.data.tables.main_tables import MainCommand
+from gs.backend.data.tables.transactional_tables import ARORequest
 
 
 class MainCommandsResponse(BaseModel):
@@ -9,3 +10,11 @@ class MainCommandsResponse(BaseModel):
     """
 
     data: list[MainCommand]
+
+
+class ARORequestsResponse(BaseModel):
+    """
+    The ARO requests response model.
+    """
+
+    data: list[ARORequest]

--- a/gs/backend/data/data_wrappers/wrappers.py
+++ b/gs/backend/data/data_wrappers/wrappers.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from gs.backend.data.data_wrappers.abstract_wrapper import AbstractWrapper  # SEE abstract_wrapper.py FOR LOGIC
+from gs.backend.data.enums.aro_requests import ARORequestStatus
 from gs.backend.data.tables.aro_user_tables import AROUserAuthToken, AROUserLogin, AROUsers
 from gs.backend.data.tables.main_tables import MainCommand, MainTelemetry
 from gs.backend.data.tables.transactional_tables import (
@@ -44,6 +45,35 @@ class ARORequestWrapper(AbstractWrapper[ARORequest, UUID]):
     """
 
     model = ARORequest
+
+    def get_requests(
+        self,
+        count: int = 100,
+        offset: int = 0,
+        filters: list[ARORequestStatus] | None = None,
+    ) -> list[ARORequest]:
+        """
+        Get recent ARO requests, optionally filtered by status.
+
+        :param count: Number of most recent requests to return. If count <= 0, returns all.
+        :param offset: Starting index (for paging) in the descending-by-created_on request list.
+        :param filters: Optional list of statuses to include.
+        :return: A list of ARO requests matching criteria.
+        """
+        requests = self.get_all()
+
+        if filters:
+            filter_set = set(filters)
+            requests = [request for request in requests if request.status in filter_set]
+
+        requests.sort(key=lambda request: request.created_on, reverse=True)
+
+        start = max(offset, 0)
+        if count <= 0:
+            return requests[start:]
+
+        end = start + count
+        return requests[start:end]
 
 
 class MainCommandWrapper(AbstractWrapper[MainCommand, int]):

--- a/python_test/test_aro_requests_api.py
+++ b/python_test/test_aro_requests_api.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from gs.backend.data.enums.aro_requests import ARORequestStatus
+from gs.backend.data.tables.aro_user_tables import AROUsers
+from gs.backend.data.tables.transactional_tables import ARORequest
+from gs.backend.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def seeded_aro_requests(db_session):
+    user = AROUsers(
+        call_sign="ABC123",
+        email="aro-user@test.com",
+        first_name="ARO",
+        last_name="User",
+        phone_number="1234567890",
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    base_time = datetime(2025, 1, 1, 0, 0, 0)
+    requests = [
+        ARORequest(
+            aro_id=user.id,
+            latitude=Decimal("10.000"),
+            longitude=Decimal("20.000"),
+            created_on=base_time,
+            status=ARORequestStatus.PENDING,
+        ),
+        ARORequest(
+            aro_id=user.id,
+            latitude=Decimal("11.000"),
+            longitude=Decimal("21.000"),
+            created_on=base_time + timedelta(minutes=1),
+            status=ARORequestStatus.COMPLETED,
+        ),
+        ARORequest(
+            aro_id=user.id,
+            latitude=Decimal("12.000"),
+            longitude=Decimal("22.000"),
+            created_on=base_time + timedelta(minutes=2),
+            status=ARORequestStatus.CANCELLED,
+        ),
+    ]
+
+    for request in requests:
+        db_session.add(request)
+    db_session.commit()
+
+    return requests
+
+
+def test_get_aro_requests_returns_data_field(client, seeded_aro_requests):
+    response = client.get("/api/v1/mcc/requests/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "data" in body
+    assert len(body["data"]) == 3
+
+
+def test_get_aro_requests_count_and_order(client, seeded_aro_requests):
+    response = client.get("/api/v1/mcc/requests/?count=2")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 2
+    assert data[0]["status"] == ARORequestStatus.CANCELLED.value
+    assert data[1]["status"] == ARORequestStatus.COMPLETED.value
+
+
+def test_get_aro_requests_count_le_zero_returns_all(client, seeded_aro_requests):
+    response = client.get("/api/v1/mcc/requests/?count=0")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 3
+
+
+def test_get_aro_requests_offset(client, seeded_aro_requests):
+    response = client.get("/api/v1/mcc/requests/?offset=1")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 2
+    assert data[0]["status"] == ARORequestStatus.COMPLETED.value
+
+
+def test_get_aro_requests_filters(client, seeded_aro_requests):
+    response = client.get(f"/api/v1/mcc/requests/?filters={ARORequestStatus.PENDING.value}")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["status"] == ARORequestStatus.PENDING.value


### PR DESCRIPTION
**Purpose**
Closes #349. Adds MCC API support to retrieve ARO requests with paging and optional status filtering.

**New Changes**
Added a GET endpoint for MCC ARO requests
Implemented request retrieval logic with sorting, paging, and optional status filtering.
Wired the endpoint into the MCC router and response model.


