### PR TITLE
Add CMD_CAPTURE_IMAGE command

### DIFF
--- a/obc/app/modules/CMakeLists.txt
+++ b/obc/app/modules/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/camera_mgr/payload_manager.c
     ${CMAKE_CURRENT_SOURCE_DIR}/camera_mgr/camera_control.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/camera_mgr/camera_fs_utils.c
 
     ${CMAKE_CURRENT_SOURCE_DIR}/command_mgr/command_manager.c
     ${CMAKE_CURRENT_SOURCE_DIR}/command_mgr/command_callbacks.c

--- a/obc/app/modules/camera_mgr/camera_fs_utils.c
+++ b/obc/app/modules/camera_mgr/camera_fs_utils.c
@@ -1,0 +1,138 @@
+#include "camera_fs_utils.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_reliance_fs.h"
+
+#include <redposix.h>
+
+#include <FreeRTOS.h>
+#include <os_semphr.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Guards the image file for an entire open -> close session; see initImageFileMutex()
+static SemaphoreHandle_t imageFileMutex = NULL;
+static StaticSemaphore_t imageFileMutexBuffer;
+
+void initImageFileMutex(void) {
+  if (imageFileMutex == NULL) {
+    imageFileMutex = xSemaphoreCreateMutexStatic(&imageFileMutexBuffer);
+  }
+}
+
+obc_error_code_t mkImageDir(void) {
+  obc_error_code_t errCode;
+
+  RETURN_IF_ERROR_CODE(mkDir(IMAGE_FILE_DIRECTORY));
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t openImageFileWrite(int32_t *imageFileId) {
+  obc_error_code_t errCode;
+
+  if (imageFileId == NULL) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  if (imageFileMutex == NULL) {
+    return OBC_ERR_CODE_INVALID_STATE;
+  }
+
+  if (xSemaphoreTake(imageFileMutex, portMAX_DELAY) != pdPASS) {
+    return OBC_ERR_CODE_MUTEX_TIMEOUT;
+  }
+
+  int32_t imageFile = 0;
+  errCode = openFile(IMAGE_FILE_PATH, RED_O_WRONLY | RED_O_CREAT | RED_O_TRUNC, &imageFile);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    xSemaphoreGive(imageFileMutex);
+    return errCode;
+  }
+
+  *imageFileId = imageFile;
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t openImageFileRO(int32_t *imageFileId) {
+  obc_error_code_t errCode;
+
+  if (imageFileId == NULL) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  if (imageFileMutex == NULL) {
+    return OBC_ERR_CODE_INVALID_STATE;
+  }
+
+  if (xSemaphoreTake(imageFileMutex, portMAX_DELAY) != pdPASS) {
+    return OBC_ERR_CODE_MUTEX_TIMEOUT;
+  }
+
+  int32_t imageFile = 0;
+  errCode = openFile(IMAGE_FILE_PATH, RED_O_RDONLY, &imageFile);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    xSemaphoreGive(imageFileMutex);
+    return errCode;
+  }
+
+  *imageFileId = imageFile;
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t closeImageFile(int32_t imageFileId) {
+  obc_error_code_t errCode = closeFile(imageFileId);
+
+  // Release the session mutex even if the close itself failed; the session is over either way
+  if (imageFileMutex != NULL) {
+    xSemaphoreGive(imageFileMutex);
+  }
+
+  return errCode;
+}
+
+obc_error_code_t writeImageToFile(int32_t imageFileId, const uint8_t *data, size_t dataLen) {
+  // Assume file is open and valid
+  obc_error_code_t errCode;
+
+  if (data == NULL || dataLen == 0) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  RETURN_IF_ERROR_CODE(writeFile(imageFileId, data, dataLen));
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t readNextImageChunkFromFile(int32_t imageFileId, uint8_t *buffer, size_t bufferSize,
+                                            size_t *bytesRead) {
+  // Assume file is open and valid
+  obc_error_code_t errCode;
+
+  if (buffer == NULL || bytesRead == NULL || bufferSize == 0) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  RETURN_IF_ERROR_CODE(readFile(imageFileId, buffer, bufferSize, bytesRead));
+
+  if (*bytesRead == 0) {
+    return OBC_ERR_CODE_REACHED_EOF;
+  }
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+obc_error_code_t getImageFileSize(int32_t imageFileId, size_t *fileSize) {
+  obc_error_code_t errCode;
+
+  if (fileSize == NULL) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  RETURN_IF_ERROR_CODE(getFileSize(imageFileId, fileSize));
+
+  return OBC_ERR_CODE_SUCCESS;
+}

--- a/obc/app/modules/camera_mgr/camera_fs_utils.h
+++ b/obc/app/modules/camera_mgr/camera_fs_utils.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "obc_errors.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Image file path config */
+#define IMAGE_FILE_DIRECTORY "/arducam/"
+#define IMAGE_FILE_PATH IMAGE_FILE_DIRECTORY "image.jpg"
+
+/**
+ * @brief Initialize the mutex guarding access to the image file. Must be called
+ *        once before the scheduler starts (i.e. from a task init function).
+ *
+ * The image file is written by the payload manager task and read by the downlink
+ * encoder task. The mutex is held for an entire open -> close session (taken by
+ * the open functions, released by closeImageFile), so a capture can never
+ * truncate the file while a downlink is mid-read, and vice versa.
+ */
+void initImageFileMutex(void);
+
+/**
+ * @brief Create the image directory.
+ *
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ */
+obc_error_code_t mkImageDir(void);
+
+/**
+ * @brief Open the image file for writing. The file is created if it does not
+ *        exist and truncated if it does, so stale data from a previous
+ *        (possibly larger) image is never left behind.
+ *
+ * @param imageFileId Buffer to store the image file descriptor
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ * @note Blocks until the image file mutex is available; the mutex is released by closeImageFile
+ */
+obc_error_code_t openImageFileWrite(int32_t *imageFileId);
+
+/**
+ * @brief Open the image file in read-only mode.
+ *
+ * @param imageFileId Buffer to store the image file descriptor
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ * @note Blocks until the image file mutex is available; the mutex is released by closeImageFile
+ */
+obc_error_code_t openImageFileRO(int32_t *imageFileId);
+
+/**
+ * @brief Close the image file and release the image file mutex.
+ *
+ * @param imageFileId File descriptor given by Reliance Edge
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ */
+obc_error_code_t closeImageFile(int32_t imageFileId);
+
+/**
+ * @brief Write a chunk of image data to the image file.
+ *
+ * @param imageFileId File descriptor given by Reliance Edge
+ * @param data Image data to write to file
+ * @param dataLen Length of the data in bytes
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ * @note File must already be opened for writing
+ */
+obc_error_code_t writeImageToFile(int32_t imageFileId, const uint8_t *data, size_t dataLen);
+
+/**
+ * @brief Read the next chunk of image data from the image file.
+ *
+ * @param imageFileId File descriptor given by Reliance Edge
+ * @param buffer Buffer to store the read data
+ * @param bufferSize Size of the buffer in bytes
+ * @param bytesRead Buffer to store the number of bytes read; the last chunk of
+ *                  the file may be smaller than bufferSize
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful,
+ *         OBC_ERR_CODE_REACHED_EOF if there is no data left to read, otherwise error code
+ * @note File must already be opened for reading
+ */
+obc_error_code_t readNextImageChunkFromFile(int32_t imageFileId, uint8_t *buffer, size_t bufferSize, size_t *bytesRead);
+
+/**
+ * @brief Get the size of the image file in bytes.
+ *
+ * @param imageFileId File descriptor given by Reliance Edge
+ * @param fileSize Buffer to store the file size
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ */
+obc_error_code_t getImageFileSize(int32_t imageFileId, size_t *fileSize);

--- a/obc/app/modules/camera_mgr/payload_manager.c
+++ b/obc/app/modules/camera_mgr/payload_manager.c
@@ -1,5 +1,9 @@
 #include "payload_manager.h"
+#include "camera_control.h"
+#include "camera_fs_utils.h"
+#include "downlink_encoder.h"
 #include "obc_errors.h"
+#include "obc_logging.h"
 #include "obc_scheduler_config.h"
 
 #include <FreeRTOS.h>
@@ -9,6 +13,13 @@
 
 #include <sys_common.h>
 #include <gio.h>
+
+/* Number of image bytes read from the camera FIFO and written to the SD card at a time */
+#define IMAGE_CHUNK_SIZE 64U
+
+/* Capture completion polling config */
+#define CAPTURE_DONE_POLL_PERIOD pdMS_TO_TICKS(10)
+#define CAPTURE_DONE_MAX_POLLS 300U
 
 static QueueHandle_t payloadQueueHandle = NULL;
 static StaticQueue_t payloadQueue;
@@ -20,6 +31,8 @@ void obcTaskInitPayloadMgr(void) {
     payloadQueueHandle = xQueueCreateStatic(PAYLOAD_MANAGER_QUEUE_LENGTH, PAYLOAD_MANAGER_QUEUE_ITEM_SIZE,
                                             payloadQueueStack, &payloadQueue);
   }
+
+  initImageFileMutex();
 }
 
 obc_error_code_t sendToPayloadQueue(payload_event_t *event) {
@@ -33,7 +46,69 @@ obc_error_code_t sendToPayloadQueue(payload_event_t *event) {
   return OBC_ERR_CODE_QUEUE_FULL;
 }
 
+/**
+ * @brief Capture an image with the selected camera and store it on the SD card at IMAGE_FILE_PATH.
+ *
+ * @param cameraID Camera ID of camera
+ * @return obc_error_code_t OBC_ERR_CODE_SUCCESS if successful, otherwise error code
+ */
+static obc_error_code_t captureImageToSD(camera_id_t cameraID) {
+  obc_error_code_t errCode;
+
+  RETURN_IF_ERROR_CODE(initCamera(cameraID));
+  RETURN_IF_ERROR_CODE(camConfigureSensor());
+  RETURN_IF_ERROR_CODE(startImageCapture(cameraID));
+
+  uint32_t polls = 0;
+  while (1) {
+    errCode = isCaptureDone(cameraID);
+    if (errCode == OBC_ERR_CODE_CAMERA_CAPTURE_COMPLETE) {
+      break;
+    }
+    if (errCode != OBC_ERR_CODE_CAMERA_CAPTURE_INCOMPLETE) {
+      return errCode;
+    }
+    if (polls >= CAPTURE_DONE_MAX_POLLS) {
+      return OBC_ERR_CODE_CAMERA_CAPTURE_INCOMPLETE;
+    }
+    polls++;
+    vTaskDelay(CAPTURE_DONE_POLL_PERIOD);
+  }
+
+  RETURN_IF_ERROR_CODE(mkImageDir());
+
+  int32_t imageFileId = -1;
+  RETURN_IF_ERROR_CODE(openImageFileWrite(&imageFileId));
+
+  // Read the image out of the camera FIFO and onto the SD card in chunks small
+  // enough to fit on the task stack
+  uint8_t imageChunk[IMAGE_CHUNK_SIZE];
+  obc_error_code_t readCode;
+  do {
+    size_t bytesRead = 0;
+    readCode = readImage(cameraID, imageChunk, IMAGE_CHUNK_SIZE, &bytesRead);
+    if ((readCode != OBC_ERR_CODE_SUCCESS) && (readCode != OBC_ERR_CODE_CAMERA_IMAGE_READ_INCOMPLETE)) {
+      closeImageFile(imageFileId);
+      return readCode;
+    }
+
+    if (bytesRead > 0) {
+      errCode = writeImageToFile(imageFileId, imageChunk, bytesRead);
+      if (errCode != OBC_ERR_CODE_SUCCESS) {
+        closeImageFile(imageFileId);
+        return errCode;
+      }
+    }
+  } while (readCode == OBC_ERR_CODE_CAMERA_IMAGE_READ_INCOMPLETE);
+
+  RETURN_IF_ERROR_CODE(closeImageFile(imageFileId));
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
 void obcTaskFunctionPayloadMgr(void *pvParameters) {
+  obc_error_code_t errCode;
+
   ASSERT(payloadQueueHandle != NULL);
 
   while (1) {
@@ -42,6 +117,22 @@ void obcTaskFunctionPayloadMgr(void *pvParameters) {
       switch (queueMsg.eventID) {
         case PAYLOAD_MANAGER_NULL_EVENT_ID:
           break;
+
+        case PAYLOAD_CAPTURE_IMAGE_EVENT_ID: {
+          LOG_IF_ERROR_CODE(captureImageToSD(PRIMARY));
+          obc_error_code_t captureCode = errCode;
+
+          // Always attempt to put the camera back into standby, even if the capture failed
+          LOG_IF_ERROR_CODE(standbyCamera(PRIMARY));
+
+          // The image file is only complete once captureImageToSD has succeeded, so this is
+          // the only place a downlink of the image may be triggered from
+          if (captureCode == OBC_ERR_CODE_SUCCESS) {
+            encode_event_t encodeEvent = {.eventID = DOWNLINK_IMAGE_FILE};
+            LOG_IF_ERROR_CODE(sendToDownlinkEncodeQueue(&encodeEvent));
+          }
+          break;
+        }
 
         case SECONDARY_PAYLOAD_MANAGER_EVENT_ID:
           // ADD SECONDARY PAYLOAD COMMAND HANDLER

--- a/obc/app/modules/camera_mgr/payload_manager.h
+++ b/obc/app/modules/camera_mgr/payload_manager.h
@@ -10,7 +10,11 @@
  *
  * Enum containing all possible event IDs passed to the payload event queue.
  */
-typedef enum { PAYLOAD_MANAGER_NULL_EVENT_ID, SECONDARY_PAYLOAD_MANAGER_EVENT_ID } payload_event_id_t;
+typedef enum {
+  PAYLOAD_MANAGER_NULL_EVENT_ID,
+  PAYLOAD_CAPTURE_IMAGE_EVENT_ID,
+  SECONDARY_PAYLOAD_MANAGER_EVENT_ID
+} payload_event_id_t;
 
 /**
  * @union	payload_event_data_t

--- a/obc/app/modules/command_mgr/command_callbacks.c
+++ b/obc/app/modules/command_mgr/command_callbacks.c
@@ -1,3 +1,6 @@
+#include "arducam.h"
+#include "camera_control.h"
+#include "hal_stdtypes.h"
 #include "obc_gs_command_data.h"
 #include "obc_gs_command_id.h"
 #include "obc_i2c_io.h"
@@ -116,6 +119,43 @@ static obc_error_code_t I2CProbeCmdCallback(cmd_msg_t *cmd, uint8_t *responseDat
   return OBC_ERR_CODE_SUCCESS;
 }
 
+static obc_error_code_t captureImageCmdCallback(cmd_msg_t *cmd, uint8_t *responseData, uint8_t *responseDataLen) {
+  obc_error_code_t errCode;
+
+  if (cmd == NULL || responseData == NULL || responseDataLen == NULL) {
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+  // setup and configure camera
+  LOG_DEBUG("Starting Arducam\r\n");
+  camera_id_t selectedCamera = PRIMARY;
+  LOG_IF_ERROR_CODE(initCamera(selectedCamera));
+  LOG_DEBUG("Configuring Camera\r\n");
+  LOG_IF_ERROR_CODE(camConfigureSensor());
+
+  // capture one image
+  LOG_IF_ERROR_CODE(startImageCapture(selectedCamera));
+  while (isCaptureDone(selectedCamera) == OBC_ERR_CODE_CAMERA_CAPTURE_INCOMPLETE)
+    ;
+
+  // read and downlink image in 64-byte chunks
+  uint8_t imgBuffer[64U];
+  size_t bytesRead = 0;
+  obc_error_code_t ret;
+  do {
+    ret = readImage(selectedCamera, imgBuffer, 64U, &bytesRead);
+    for (size_t i = 0; i < bytesRead; i++) {
+      encode_event_t event = {.eventID = DOWNLINK_CMD_RESPONSE, .cmdResponseByte = imgBuffer[i]};
+      RETURN_IF_ERROR_CODE(sendToDownlinkEncodeQueue(&event));
+    }
+  } while (ret == OBC_ERR_CODE_CAMERA_IMAGE_READ_INCOMPLETE);
+
+  // finished, put camera on standby
+  LOG_IF_ERROR_CODE(standbyCamera(selectedCamera));
+  *responseDataLen = 0;
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
 const cmd_info_t cmdsConfig[] = {
     [CMD_END_OF_FRAME] = {NULL, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     // TODO: Change this to critial once critical commands are implemented
@@ -126,6 +166,7 @@ const cmd_info_t cmdsConfig[] = {
     [CMD_PING] = {pingCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_DOWNLINK_TELEM] = {downlinkTelemCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
     [CMD_I2C_PROBE] = {I2CProbeCmdCallback, CMD_POLICY_PROD, CMD_TYPE_NORMAL},
+    [CMD_CAPTURE_IMAGE] = {captureImageCmdCallback, CMD_POLICY_RND, CMD_TYPE_NORMAL},
 };
 
 // This function is purely to trick the compiler into thinking we are using the cmdsConfig variable so we avoid the

--- a/obc/app/modules/command_mgr/command_callbacks.c
+++ b/obc/app/modules/command_mgr/command_callbacks.c
@@ -1,5 +1,3 @@
-#include "arducam.h"
-#include "camera_control.h"
 #include "hal_stdtypes.h"
 #include "obc_gs_command_data.h"
 #include "obc_gs_command_id.h"
@@ -9,8 +7,8 @@
 #include "obc_logging.h"
 #include "obc_time.h"
 #include "obc_time_utils.h"
-#include "downlink_encoder.h"
 #include "os_portmacro.h"
+#include "payload_manager.h"
 #include "os_projdefs.h"
 #include "telemetry_manager.h"
 #include "command.h"
@@ -125,32 +123,13 @@ static obc_error_code_t captureImageCmdCallback(cmd_msg_t *cmd, uint8_t *respons
   if (cmd == NULL || responseData == NULL || responseDataLen == NULL) {
     return OBC_ERR_CODE_INVALID_ARG;
   }
-  // setup and configure camera
-  LOG_DEBUG("Starting Arducam\r\n");
-  camera_id_t selectedCamera = PRIMARY;
-  LOG_IF_ERROR_CODE(initCamera(selectedCamera));
-  LOG_DEBUG("Configuring Camera\r\n");
-  LOG_IF_ERROR_CODE(camConfigureSensor());
 
-  // capture one image
-  LOG_IF_ERROR_CODE(startImageCapture(selectedCamera));
-  while (isCaptureDone(selectedCamera) == OBC_ERR_CODE_CAMERA_CAPTURE_INCOMPLETE)
-    ;
+  // The capture is handled asynchronously by the payload manager, which writes
+  // the image to the SD card; a successful response only means the capture
+  // request was queued
+  payload_event_t event = {.eventID = PAYLOAD_CAPTURE_IMAGE_EVENT_ID};
+  RETURN_IF_ERROR_CODE(sendToPayloadQueue(&event));
 
-  // read and downlink image in 64-byte chunks
-  uint8_t imgBuffer[64U];
-  size_t bytesRead = 0;
-  obc_error_code_t ret;
-  do {
-    ret = readImage(selectedCamera, imgBuffer, 64U, &bytesRead);
-    for (size_t i = 0; i < bytesRead; i++) {
-      encode_event_t event = {.eventID = DOWNLINK_CMD_RESPONSE, .cmdResponseByte = imgBuffer[i]};
-      RETURN_IF_ERROR_CODE(sendToDownlinkEncodeQueue(&event));
-    }
-  } while (ret == OBC_ERR_CODE_CAMERA_IMAGE_READ_INCOMPLETE);
-
-  // finished, put camera on standby
-  LOG_IF_ERROR_CODE(standbyCamera(selectedCamera));
   *responseDataLen = 0;
 
   return OBC_ERR_CODE_SUCCESS;

--- a/obc/app/modules/comms_link_mgr/downlink_encoder.c
+++ b/obc/app/modules/comms_link_mgr/downlink_encoder.c
@@ -1,8 +1,11 @@
 #include "downlink_encoder.h"
+#include "camera_fs_utils.h"
 #include "cc1120_txrx.h"
 #include "obc_board_config.h"
 #include "obc_gs_ax25.h"
+#include "obc_gs_command_id.h"
 #include "obc_gs_commands_response.h"
+#include "obc_gs_commands_response_pack.h"
 #include "obc_gs_fec.h"
 
 #include "obc_gs_telemetry_pack.h"
@@ -71,6 +74,16 @@ static obc_error_code_t getFileDescriptor(uint32_t telemetryBatchId, int32_t *fd
 static obc_error_code_t sendPacket(uint8_t *sendBuffer);
 
 /**
+ * @brief Reads the image file off the SD card and sends it into the CC1120
+ * transmit queue as a series of cmd-response-format packets. The first packet
+ * carries the total image size (4 bytes, little-endian); each following packet
+ * carries up to CMD_RESPONSE_DATA_MAX_SIZE (220) bytes of image data.
+ *
+ * @return obc_error_code_t - OBC_ERR_CODE_SUCCESS if the whole image was sent
+ */
+static obc_error_code_t sendImageFile(void);
+
+/**
  * @brief Either sends a single piece of telemetry or packs it into the current
  * telemetry packet
  *
@@ -133,6 +146,12 @@ void obcTaskFunctionCommsDownlinkEncoder(void *pvParameters) {
         setCurrentLinkDestCallSign(GROUND_STATION_CALLSIGN, CALLSIGN_LENGTH, DEFAULT_SSID);
         LOG_IF_ERROR_CODE(
             sendTelemetryBuffer(queueMsg.telemetryDataBuffer.telemData, queueMsg.telemetryDataBuffer.bufferSize));
+        transmitEvent.eventID = END_DOWNLINK;
+        LOG_IF_ERROR_CODE(sendToCC1120TransmitQueue(&transmitEvent));
+        break;
+      case DOWNLINK_IMAGE_FILE:
+        setCurrentLinkDestCallSign(GROUND_STATION_CALLSIGN, CALLSIGN_LENGTH, DEFAULT_SSID);
+        LOG_IF_ERROR_CODE(sendImageFile());
         transmitEvent.eventID = END_DOWNLINK;
         LOG_IF_ERROR_CODE(sendToCC1120TransmitQueue(&transmitEvent));
         break;
@@ -332,6 +351,78 @@ static obc_error_code_t sendOrPackNextTelemetry(telemetry_data_t *singleTelem, p
   // Copy the telemetry data into the packedTelem struct
   memcpy(telemPacket->data + (*telemPacketOffset), packedSingleTelem, packedSingleTelemSize);
   *telemPacketOffset += packedSingleTelemSize;
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+static obc_error_code_t sendImageFile(void) {
+  obc_error_code_t errCode;
+
+  // Taking the image file mutex (inside openImageFileRO) guarantees the payload
+  // manager is not still writing this image, and blocks any new capture from
+  // truncating the file until we close it
+  int32_t imageFileId = -1;
+  RETURN_IF_ERROR_CODE(openImageFileRO(&imageFileId));
+
+  size_t fileSize = 0;
+  errCode = getImageFileSize(imageFileId, &fileSize);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return errCode;
+  }
+
+  uint8_t packetBuffer[RS_DECODED_SIZE] = {0};
+  // packCmdResponse always copies CMD_RESPONSE_DATA_MAX_SIZE bytes from responseData,
+  // so it must be a full-size, zeroed buffer even when dataLen is smaller
+  uint8_t responseData[CMD_RESPONSE_DATA_MAX_SIZE] = {0};
+
+  // First packet: total image size, so the ground station knows how many data bytes to expect
+  uint32_t imageSize = (uint32_t)fileSize;
+  memcpy(responseData, &imageSize, sizeof(imageSize));
+  cmd_response_header_t resHeader = {
+      .cmdId = CMD_CAPTURE_IMAGE, .errCode = CMD_RESPONSE_SUCCESS, .dataLen = sizeof(imageSize)};
+  if (packCmdResponse(&resHeader, packetBuffer, responseData) != OBC_GS_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return OBC_ERR_CODE_FAILED_PACK;
+  }
+  errCode = sendPacket(packetBuffer);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return errCode;
+  }
+
+  // Data packets: up to 220 bytes of raw image data each; the last one may be short
+  while (1) {
+    size_t bytesRead = 0;
+    memset(responseData, 0, sizeof(responseData));
+    errCode = readNextImageChunkFromFile(imageFileId, responseData, CMD_RESPONSE_DATA_MAX_SIZE, &bytesRead);
+    if (errCode == OBC_ERR_CODE_REACHED_EOF) {
+      errCode = OBC_ERR_CODE_SUCCESS;
+      break;
+    }
+    if (errCode != OBC_ERR_CODE_SUCCESS) {
+      break;
+    }
+
+    resHeader.dataLen = (uint8_t)bytesRead;
+    if (packCmdResponse(&resHeader, packetBuffer, responseData) != OBC_GS_ERR_CODE_SUCCESS) {
+      errCode = OBC_ERR_CODE_FAILED_PACK;
+      break;
+    }
+
+    errCode = sendPacket(packetBuffer);
+    if (errCode != OBC_ERR_CODE_SUCCESS) {
+      break;
+    }
+  }
+
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    LOG_ERROR_CODE(errCode);
+    closeImageFile(imageFileId);
+    return errCode;
+  }
+
+  RETURN_IF_ERROR_CODE(closeImageFile(imageFileId));
 
   return OBC_ERR_CODE_SUCCESS;
 }

--- a/obc/app/modules/comms_link_mgr/downlink_encoder.h
+++ b/obc/app/modules/comms_link_mgr/downlink_encoder.h
@@ -6,7 +6,12 @@
 #include "obc_errors.h"
 #include "comms_manager.h"
 
-typedef enum { DOWNLINK_TELEMETRY_FILE, DOWNLINK_DATA_BUFFER, DOWNLINK_CMD_RESPONSE } encode_event_id_t;
+typedef enum {
+  DOWNLINK_TELEMETRY_FILE,
+  DOWNLINK_DATA_BUFFER,
+  DOWNLINK_CMD_RESPONSE,
+  DOWNLINK_IMAGE_FILE
+} encode_event_id_t;
 
 typedef struct {
   telemetry_data_t telemData[MAX_DOWNLINK_TELEM_BUFFER_SIZE];

--- a/obc/app/rtos/obc_scheduler_config.c
+++ b/obc/app/rtos/obc_scheduler_config.c
@@ -73,7 +73,7 @@ static StackType_t obcTaskStackCommandMgr[1024U];
 static StaticTask_t obcTaskBufferCommandMgr;
 static StackType_t obcTaskStackCommsMgr[1024U];
 static StaticTask_t obcTaskBufferCommsMgr;
-static StackType_t obcTaskStackCommsDownlinkEncoder[512U];
+static StackType_t obcTaskStackCommsDownlinkEncoder[1024U];
 static StaticTask_t obcTaskBufferCommsDownlinkEncoder;
 static StackType_t obcTaskStackCommsUplinkDecoder[1024U];
 static StaticTask_t obcTaskBufferCommsUplinkDecoder;
@@ -144,7 +144,7 @@ static obc_scheduler_config_t obcSchedulerConfig[] = {
             .taskName = "comms_encoder",
             .taskStack = obcTaskStackCommsDownlinkEncoder,
             .taskBuffer = &obcTaskBufferCommsDownlinkEncoder,
-            .stackSize = 512U,
+            .stackSize = 1024U,
             .priority = TASK_COMMS_PRIORITY,
             .taskFunc = obcTaskFunctionCommsDownlinkEncoder,
             .taskInit = obcTaskInitCommsDownlinkEncoder,

--- a/obc/app/rtos/scheduler_config.toml
+++ b/obc/app/rtos/scheduler_config.toml
@@ -34,7 +34,7 @@ config_id_stem = "COMMS_MGR"
 
 [[tasks]]
 task_name = "comms_encoder"
-stack_size = 512
+stack_size = 1024
 priority = "TASK_COMMS_PRIORITY"
 function_stem = "CommsDownlinkEncoder"
 config_id_stem = "COMMS_DOWNLINK_ENCODER"

--- a/obc/examples/test_app_arducam/main.c
+++ b/obc/examples/test_app_arducam/main.c
@@ -1,124 +1,375 @@
-#include "obc_logging.h"
+/**
+ * ============================================================================
+ * ARDUCAM PAYLOAD PIPELINE DEMO (SD-card image path, no camera required)
+ * ============================================================================
+ *
+ * This example demonstrates the full "image on SD card" payload pipeline using
+ * STUB DATA instead of a real ArduCam, so it can run on any board with an SD
+ * card. It exercises the exact same code the flight software uses
+ * (camera_fs_utils + the packet format used by the downlink encoder).
+ *
+ * -------------------------- HOW THE REAL SYSTEM WORKS ----------------------
+ *
+ * 1) UPLINK: the ground station (GS) sends CMD_CAPTURE_IMAGE. It arrives over
+ *    the radio (CC1120) or UART, is AX.25-deframed, RS-decoded and AES-decrypted
+ *    by the uplink decoder, and lands in the command manager's queue.
+ *
+ * 2) COMMAND CALLBACK (command_callbacks.c): captureImageCmdCallback() does NOT
+ *    touch the camera. It only queues a PAYLOAD_CAPTURE_IMAGE_EVENT_ID event to
+ *    the payload manager and returns, so the command manager task is never
+ *    blocked by a slow capture. The command response only means "capture
+ *    request queued".
+ *
+ * 3) PAYLOAD MANAGER (payload_manager.c): its task receives the event and runs
+ *    captureImageToSD():
+ *      - initCamera / camConfigureSensor / startImageCapture
+ *      - polls isCaptureDone() every 10 ms (bounded, no busy-spin)
+ *      - streams the ArduCam FIFO to the SD card in 64-byte chunks via
+ *        camera_fs_utils, so the full image (much larger than any task stack)
+ *        is never held in RAM
+ *      - the image lives at IMAGE_FILE_PATH ("/arducam/image.jpg"), truncated
+ *        and rewritten on every capture
+ *    On success (and only then) it queues a DOWNLINK_IMAGE_FILE event to the
+ *    downlink encoder: the downlink can therefore never start before the image
+ *    is fully written.
+ *
+ * 4) CONCURRENCY: camera_fs_utils holds a mutex for an entire open -> close
+ *    session (openImageFileWrite/openImageFileRO take it, closeImageFile
+ *    releases it). This prevents the one remaining race: a NEW capture
+ *    truncating the file while a still-running downlink is reading it.
+ *
+ * 5) DOWNLINK ENCODER (downlink_encoder.c): sendImageFile() opens the file
+ *    read-only, then sends:
+ *      - packet 0: a cmd-response packet whose 4-byte payload is the total
+ *        image size (little-endian) -> tells the GS how many bytes to expect
+ *      - packets 1..N: cmd-response packets each carrying up to 220 bytes of
+ *        raw image data (the last one may be short)
+ *    Each 223-byte packet then gets Reed-Solomon FEC (-> 255 B) and AX.25
+ *    framing before hitting the radio/UART.
+ *
+ *    CMD-RESPONSE PACKET LAYOUT (223 bytes total, before FEC/AX.25):
+ *      byte 0   : cmdId   (CMD_CAPTURE_IMAGE)
+ *      byte 1   : errCode (CMD_RESPONSE_SUCCESS)
+ *      byte 2   : dataLen (0..220)
+ *      byte 3.. : dataLen bytes of payload, zero-padded to 220
+ *
+ * ----------------------------- WHAT THIS DEMO DOES -------------------------
+ *
+ *  STEP 1 (stands in for the payload manager write path):
+ *    - init the image file mutex and mount the filesystem
+ *    - generate a recognizable ASCII stub "image" and write it to
+ *      /arducam/image.jpg in 64-byte chunks, exactly like captureImageToSD()
+ *      (only the camera FIFO reads are replaced by the stub buffer)
+ *
+ *  STEP 2 (stands in for the downlink encoder + ground station):
+ *    - open the file read-only, get its size
+ *    - build the same packets sendImageFile() builds (size packet + 220-byte
+ *      data packets) using the real packCmdResponse()
+ *    - "transmit" each packet by parsing it the way the GS would (read the
+ *      3-byte header, take dataLen payload bytes) and reassembling the image
+ *    - verify the reassembled bytes match the stub byte-for-byte and print
+ *      the recovered text over UART
+ *
+ * ------------------------------- FUTURE WORK -------------------------------
+ *  - GS side: parse the size packet + data packets and reassemble image.jpg
+ *    (this demo's STEP 2 parsing loop is the reference implementation)
+ *  - Optionally add a dedicated CMD_DOWNLINK_IMAGE ground command (in the
+ *    interfaces submodule) instead of auto-downlinking after every capture
+ *  - Persist multiple images / add image metadata (timestamp, camera ID)
+ *  - Run this same pipeline with the real camera by swapping the stub buffer
+ *    for readImage() calls (that code already exists in payload_manager.c)
+ * ============================================================================
+ */
+
 #include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_reliance_fs.h"
 #include "obc_sci_io.h"
 #include "obc_spi_io.h"
-#include "obc_i2c_io.h"
-#include "obc_print.h"
 
-#include "arducam.h"
-#include "camera_control.h"
+#include "camera_fs_utils.h"
+#include "obc_gs_command_id.h"
+#include "obc_gs_commands_response.h"
+#include "obc_gs_commands_response_pack.h"
+#include "obc_gs_errors.h"
+#include "obc_gs_fec.h"
 
-#include <gio.h>
+#include <FreeRTOS.h>
+#include <os_task.h>
+
+#include <sys_common.h>
 #include <sci.h>
 #include <spi.h>
-#include <i2c.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
 
-#define UART_MUTEX_BLOCK_TIME portMAX_DELAY
-// BUFFER_SIZE must be a multiple of 3 for base64 conversion
-#define BUFFER_SIZE 4095U
+#include <string.h>
+#include <stdint.h>
 
 #define TASK_STACK_SIZE 2048U
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[TASK_STACK_SIZE];
 
-const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+/* Stub image config. 1337 is deliberately NOT a multiple of 220 so the demo
+ * exercises a short final data packet, and NOT a multiple of 64 so the write
+ * side exercises a short final write chunk. */
+#define STUB_IMAGE_SIZE 1337U
 
-void vTask1(void *pvParameters) {
+/* Same chunk size the payload manager uses when streaming the camera FIFO to
+ * the SD card (IMAGE_CHUNK_SIZE in payload_manager.c) */
+#define WRITE_CHUNK_SIZE 64U
+
+/* The stub image and the GS-side reassembly buffer. Static (not on the task
+ * stack) because 2 x 1337 B would eat a large part of the stack. The real
+ * system never needs buffers like these - only this demo does, for
+ * verification. */
+static uint8_t stubImage[STUB_IMAGE_SIZE];
+static uint8_t reassembledImage[STUB_IMAGE_SIZE];
+
+/**
+ * @brief Fill the stub image buffer with a recognizable repeating ASCII
+ * message, so the "downlinked" data is human-readable on the UART console.
+ */
+static void generateStubImage(void) {
+  const char msg[] = "UW ORBITAL ARDUCAM SD-CARD PAYLOAD DEMO! ";
+  const size_t msgLen = sizeof(msg) - 1U;  // exclude null terminator
+  for (size_t i = 0; i < STUB_IMAGE_SIZE; i++) {
+    stubImage[i] = (uint8_t)msg[i % msgLen];
+  }
+}
+
+/**
+ * @brief STEP 1: write the stub image to /arducam/image.jpg in 64-byte chunks.
+ *
+ * This mirrors captureImageToSD() in payload_manager.c one-for-one; the only
+ * difference is that the data comes from stubImage[] instead of the ArduCam
+ * FIFO (readImage()).
+ */
+static obc_error_code_t writeStubImageToSD(void) {
   obc_error_code_t errCode;
-  sciPrintf("Starting Arducam Demo\r\n");
-  camera_id_t selectedCamera = PRIMARY;
-  LOG_IF_ERROR_CODE(initCamera(selectedCamera));
-  uint8_t temp;
-  LOG_IF_ERROR_CODE(arducamReadSensorPowerControlReg(selectedCamera, &temp));
-  sciPrintf("Power Control Reg:0x%X\r\n", temp);
 
-  // Read Camera Sensor ID
-  uint16_t cam_id;
-  LOG_IF_ERROR_CODE(ov5642GetChipID(&cam_id));
-  sciPrintf("Sensor ID: %X\r\n", cam_id);
+  // Idempotent - succeeds if /arducam/ already exists
+  RETURN_IF_ERROR_CODE(mkImageDir());
 
-  // Test Reg operations
-  uint8_t byte = 0x55;
-  sciPrintf("Writing %d to test reg\r\n", byte);
-  LOG_IF_ERROR_CODE(arducamWriteTestReg(selectedCamera, byte));
-  byte = 0;
-  LOG_IF_ERROR_CODE(arducamReadTestReg(selectedCamera, &byte));
-  sciPrintf("Read %d from test reg\r\n", byte);
+  // Takes the image file mutex and truncates any previous image
+  int32_t imageFileId = -1;
+  RETURN_IF_ERROR_CODE(openImageFileWrite(&imageFileId));
 
-  // Camera Configuration
-  sciPrintf("Configuring Camera\r\n");
-  LOG_IF_ERROR_CODE(camConfigureSensor());
-  for (int i = 0; i < 20; i++) {
-    // Capture
-    sciPrintf("Starting Image Capture\r\n");
-    LOG_IF_ERROR_CODE(startImageCapture(selectedCamera));
-    sciPrintf("Image Capture Started\r\n");
-
-    while (isCaptureDone(selectedCamera) == OBC_ERR_CODE_CAMERA_CAPTURE_INCOMPLETE)
-      ;
-    sciPrintf("Image Capture Done ^_^\r\n");
-
-    // Read image size
-    uint32_t img_len = 0;
-    LOG_IF_ERROR_CODE(arducamReadFIFOSize(selectedCamera, &img_len));
-    sciPrintf("image len: %d \r\n", img_len);
-
-    // Read image from FIFO
-    uint8_t imgBuffer[BUFFER_SIZE];
-    sciPrintf("FIFO Burst Read:\r\n");
-    size_t bytesRead = 0;
-    // Only print last image
-    if (i == 19) {
-      obc_error_code_t ret;
-      do {
-        ret = readImage(selectedCamera, imgBuffer, BUFFER_SIZE, &bytesRead);
-        for (size_t i = 0; i < bytesRead; i += 3) {
-          // modified from https://nachtimwald.com/2017/11/18/base64-encode-and-decode-in-c/
-          uint32_t v = imgBuffer[i];
-          v = i + 1 < bytesRead ? v << 8 | imgBuffer[i + 1] : v << 8;
-          v = i + 2 < bytesRead ? v << 8 | imgBuffer[i + 2] : v << 8;
-
-          sciPrintf("%c", b64chars[(v >> 18) & 0x3F]);
-          sciPrintf("%c", b64chars[(v >> 12) & 0x3F]);
-          if (i + 1 < bytesRead) {
-            sciPrintf("%c", b64chars[(v >> 6) & 0x3F]);
-          } else {
-            sciPrintf("=");
-          }
-          if (i + 2 < bytesRead) {
-            sciPrintf("%c", b64chars[v & 0x3F]);
-          } else {
-            sciPrintf("=");
-          }
-        }
-      } while (ret == OBC_ERR_CODE_CAMERA_IMAGE_READ_INCOMPLETE);
+  size_t bytesWritten = 0;
+  while (bytesWritten < STUB_IMAGE_SIZE) {
+    size_t chunkLen = STUB_IMAGE_SIZE - bytesWritten;
+    if (chunkLen > WRITE_CHUNK_SIZE) {
+      chunkLen = WRITE_CHUNK_SIZE;
     }
-    sciPrintf("\r\n");
+
+    errCode = writeImageToFile(imageFileId, &stubImage[bytesWritten], chunkLen);
+    if (errCode != OBC_ERR_CODE_SUCCESS) {
+      closeImageFile(imageFileId);
+      return errCode;
+    }
+    bytesWritten += chunkLen;
   }
 
-  // Put Camera on standby (gets pretty hot if left powered on for too long)
-  LOG_IF_ERROR_CODE(standbyCamera(selectedCamera));
+  // Close commits the data and releases the mutex; only after this point may a
+  // downlink read the file. In the real system, the payload manager sends the
+  // DOWNLINK_IMAGE_FILE event here.
+  RETURN_IF_ERROR_CODE(closeImageFile(imageFileId));
+
+  sciPrintf("[payload] wrote %d stub bytes to %s in %d-byte chunks\r\n", (int)bytesWritten, IMAGE_FILE_PATH,
+            (int)WRITE_CHUNK_SIZE);
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+/**
+ * @brief Parse one cmd-response packet the way the ground station will.
+ *
+ * This is the GS reference implementation: read the 3-byte header, then take
+ * dataLen payload bytes. Data packets are appended to reassembledImage[].
+ *
+ * @param packet 223-byte packet (RS_DECODED_SIZE), as produced by packCmdResponse
+ * @param isSizePacket true for packet 0 (payload = 4-byte image size)
+ * @param expectedTotal in/out - set from the size packet, checked by data packets
+ * @param reassembledLen in/out - number of image bytes recovered so far
+ */
+static obc_error_code_t gsParsePacket(const uint8_t *packet, bool isSizePacket, uint32_t *expectedTotal,
+                                      size_t *reassembledLen) {
+  // Header layout: [0]=cmdId [1]=errCode [2]=dataLen [3..]=payload
+  uint8_t cmdId = packet[0];
+  uint8_t respErrCode = packet[1];
+  uint8_t dataLen = packet[2];
+  const uint8_t *payload = &packet[3];
+
+  if (cmdId != (uint8_t)CMD_CAPTURE_IMAGE || respErrCode != (uint8_t)CMD_RESPONSE_SUCCESS) {
+    sciPrintf("[gs] unexpected header: cmdId=%d errCode=%d\r\n", cmdId, respErrCode);
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  if (isSizePacket) {
+    // Packet 0: 4-byte total image size, little-endian
+    uint32_t total = 0;
+    memcpy(&total, payload, sizeof(total));
+    *expectedTotal = total;
+    sciPrintf("[gs] size packet: expecting %d image bytes\r\n", (int)total);
+    return OBC_ERR_CODE_SUCCESS;
+  }
+
+  if (*reassembledLen + dataLen > *expectedTotal || *reassembledLen + dataLen > STUB_IMAGE_SIZE) {
+    sciPrintf("[gs] received more data than announced!\r\n");
+    return OBC_ERR_CODE_INVALID_ARG;
+  }
+
+  memcpy(&reassembledImage[*reassembledLen], payload, dataLen);
+  *reassembledLen += dataLen;
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+/**
+ * @brief STEP 2: read the image back off the SD card and packetize it exactly
+ * like sendImageFile() in downlink_encoder.c, handing each packet to the
+ * GS-side parser instead of the radio.
+ *
+ * In the real system the only difference is that each 223-byte packet goes
+ * through sendPacket() (Reed-Solomon FEC -> AX.25 framing -> CC1120/UART)
+ * instead of gsParsePacket().
+ */
+static obc_error_code_t downlinkStubImage(void) {
+  obc_error_code_t errCode;
+
+  // Takes the image file mutex: a new "capture" cannot truncate the file under us
+  int32_t imageFileId = -1;
+  RETURN_IF_ERROR_CODE(openImageFileRO(&imageFileId));
+
+  size_t fileSize = 0;
+  errCode = getImageFileSize(imageFileId, &fileSize);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return errCode;
+  }
+  sciPrintf("[downlink] image file is %d bytes\r\n", (int)fileSize);
+
+  uint8_t packetBuffer[RS_DECODED_SIZE] = {0};
+  // packCmdResponse always copies a full 220 bytes from responseData, so keep
+  // it full-size and zeroed even for short chunks
+  uint8_t responseData[CMD_RESPONSE_DATA_MAX_SIZE] = {0};
+
+  uint32_t expectedTotal = 0;
+  size_t reassembledLen = 0;
+  uint32_t packetCount = 0;
+
+  // ---- Packet 0: total image size ----
+  uint32_t imageSize = (uint32_t)fileSize;
+  memcpy(responseData, &imageSize, sizeof(imageSize));
+  cmd_response_header_t resHeader = {
+      .cmdId = CMD_CAPTURE_IMAGE, .errCode = CMD_RESPONSE_SUCCESS, .dataLen = sizeof(imageSize)};
+  if (packCmdResponse(&resHeader, packetBuffer, responseData) != OBC_GS_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return OBC_ERR_CODE_FAILED_PACK;
+  }
+  packetCount++;
+  errCode = gsParsePacket(packetBuffer, true, &expectedTotal, &reassembledLen);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    closeImageFile(imageFileId);
+    return errCode;
+  }
+
+  // ---- Packets 1..N: image data, up to 220 bytes each ----
+  while (1) {
+    size_t bytesRead = 0;
+    memset(responseData, 0, sizeof(responseData));
+    errCode = readNextImageChunkFromFile(imageFileId, responseData, CMD_RESPONSE_DATA_MAX_SIZE, &bytesRead);
+    if (errCode == OBC_ERR_CODE_REACHED_EOF) {
+      errCode = OBC_ERR_CODE_SUCCESS;
+      break;
+    }
+    if (errCode != OBC_ERR_CODE_SUCCESS) {
+      break;
+    }
+
+    resHeader.dataLen = (uint8_t)bytesRead;
+    if (packCmdResponse(&resHeader, packetBuffer, responseData) != OBC_GS_ERR_CODE_SUCCESS) {
+      errCode = OBC_ERR_CODE_FAILED_PACK;
+      break;
+    }
+    packetCount++;
+
+    errCode = gsParsePacket(packetBuffer, false, &expectedTotal, &reassembledLen);
+    if (errCode != OBC_ERR_CODE_SUCCESS) {
+      break;
+    }
+  }
+
+  closeImageFile(imageFileId);
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    return errCode;
+  }
+
+  sciPrintf("[downlink] sent %d packets (1 size + %d data)\r\n", (int)packetCount, (int)(packetCount - 1U));
+
+  // ---- GS-side verification ----
+  if (reassembledLen != expectedTotal) {
+    sciPrintf("[gs] FAIL: reassembled %d bytes, expected %d\r\n", (int)reassembledLen, (int)expectedTotal);
+    return OBC_ERR_CODE_UNKNOWN;
+  }
+  if (memcmp(reassembledImage, stubImage, STUB_IMAGE_SIZE) != 0) {
+    sciPrintf("[gs] FAIL: reassembled data does not match the stub image\r\n");
+    return OBC_ERR_CODE_UNKNOWN;
+  }
+
+  sciPrintf("[gs] PASS: all %d bytes reassembled correctly\r\n", (int)reassembledLen);
+  sciPrintf("[gs] recovered data starts with: \"");
+  sciPrintText(reassembledImage, 41, portMAX_DELAY);
+  sciPrintf("\"\r\n");
+
+  return OBC_ERR_CODE_SUCCESS;
+}
+
+static void payloadPipelineDemoTask(void *pvParameters) {
+  obc_error_code_t errCode;
+
+  sciPrintf("\r\n=== ArduCam SD-card payload pipeline demo (stub data) ===\r\n");
+
+  // In the flight build these two happen in obcTaskInitPayloadMgr() and the
+  // state manager's filesystem setup respectively
+  initImageFileMutex();
+  LOG_IF_ERROR_CODE(setupFileSystem());
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    sciPrintf("Filesystem setup failed (%d) - is the SD card inserted?\r\n", errCode);
+    while (1)
+      ;
+  }
+  sciPrintf("Filesystem mounted\r\n");
+
+  generateStubImage();
+
+  // STEP 1: payload-manager side (stub capture -> SD card)
+  LOG_IF_ERROR_CODE(writeStubImageToSD());
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    sciPrintf("Stub image write failed (%d)\r\n", errCode);
+    while (1)
+      ;
+  }
+
+  // STEP 2: downlink-encoder + GS side (SD card -> packets -> reassembled image)
+  LOG_IF_ERROR_CODE(downlinkStubImage());
+  if (errCode != OBC_ERR_CODE_SUCCESS) {
+    sciPrintf("Stub image downlink failed (%d)\r\n", errCode);
+    while (1)
+      ;
+  }
+
+  sciPrintf("=== Demo complete ===\r\n");
   while (1)
     ;
 }
+
 int main(void) {
-  // Initialize hardware.
-  gioInit();
+  // Hardware init: UART for console output, SPI for the SD card
   sciInit();
   spiInit();
-  i2cInit();
 
-  // Initialize the bus mutex.
   initSciPrint();
   initSpiMutex();
-  initI2CMutex();
 
-  initOV5642();
-
-  xTaskCreateStatic(vTask1, "Arducam", TASK_STACK_SIZE, NULL, 1, taskStack, &taskBuffer);
+  xTaskCreateStatic(payloadPipelineDemoTask, "payload_demo", TASK_STACK_SIZE, NULL, 1, taskStack, &taskBuffer);
 
   vTaskStartScheduler();
 

--- a/test/interfaces/test_command_pack_unpack.cpp
+++ b/test/interfaces/test_command_pack_unpack.cpp
@@ -242,3 +242,29 @@ TEST(TestCommandPackUnpack, ValidCmdEraseAppPackUnpack) {
   EXPECT_EQ(packOffset, unpackOffset);
   EXPECT_EQ(cmdMsg.id, unpackedCmdMsg.id);
 }
+
+// CMD_CAPTURE_IMAGE
+TEST(TestCommandPackUnpack, ValidCmdCaptureImagePackUnpack) {
+  obc_gs_error_code_t errCode;
+  cmd_msg_t cmdMsg = {0};
+  cmdMsg.id = CMD_CAPTURE_IMAGE;
+
+  uint8_t buff[MAX_CMD_MSG_SIZE] = {0};
+  uint32_t packOffset = 0;
+  uint8_t numPacked = 0;
+
+  errCode = packCmdMsg(buff, &packOffset, &cmdMsg, &numPacked);
+  ASSERT_EQ(errCode, OBC_GS_ERR_CODE_SUCCESS);
+  for (int i = 0; i < MAX_CMD_MSG_SIZE; i++) {
+    printf(" 0x%x", buff[i]);
+  }
+  printf(" %d", packOffset);
+
+  cmd_msg_t unpackedCmdMsg = {0};
+  uint32_t unpackOffset = 0;
+  errCode = unpackCmdMsg(buff, &unpackOffset, &unpackedCmdMsg);
+  ASSERT_EQ(errCode, OBC_GS_ERR_CODE_SUCCESS);
+
+  EXPECT_EQ(packOffset, unpackOffset);
+  EXPECT_EQ(cmdMsg.id, unpackedCmdMsg.id);
+}


### PR DESCRIPTION
  Address #704. This is the obc-firmware PR. The interfaces pr is linked [here](https://github.com/UWOrbital/interfaces/pull/4).
  ## Summary
  - Added `captureImageCmdCallback` in `command_callbacks.c` which initializes the Arducam, captures a single image, and streams the JPEG bytes to the downlink encoder via `DOWNLINK_CMD_RESPONSE` events
  - Registered `CMD_CAPTURE_IMAGE` in `cmdsConfig[]` with `CMD_POLICY_RND`
  - Updated interfaces submodule to include `CMD_CAPTURE_IMAGE`

  ## Notes
  - Image is streamed directly to the downlink encoder in 64-byte chunks rather than buffered, since JPEG size exceeds `CMD_RESPONSE_DATA_MAX_SIZE`

  ## Test plan
  - [x] Pack/unpack test added in interfaces repo
  - [ ] Hardware test: flash firmware, send `CMD_CAPTURE_IMAGE` from GS, verify JPEG bytes appear in PuTTY
  
## Design Decisions

  **New event type vs command response**
Used the existing `DOWNLINK_CMD_RESPONSE` event type rather than creating a new one. Since the image is just a stream of bytes and the downlink encoder already handles accumulating `DOWNLINK_CMD_RESPONSE` bytes into 223-byte RS packets, a new event type would add complexity with no benefit for this use case.

  **SD card intermediate storage vs direct downlink**
  Chosen to downlink directly without storing to SD card. This is simpler and sufficient for the current requirement (verifying the JPEG appears in PuTTY). SD card storage would be useful if we needed to retry downlinks or downlink on a future pass, but that is out of scope for this PR.