### PR TITLE
425 clang format not sorting includes by the style guide

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -165,7 +165,7 @@ RawStringFormats:
 ReferenceAlignment: Pointer
 ReflowComments:  true
 ShortNamespaceLines: 1
-SortIncludes:    false
+SortIncludes:    true
 SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/obc/app/app_main.c
+++ b/obc/app/app_main.c
@@ -1,22 +1,21 @@
-#include "obc_logging.h"
-#include "obc_sci_io.h"
-#include "obc_i2c_io.h"
-#include "obc_spi_io.h"
-#include "obc_reset.h"
-#include "obc_scheduler_config.h"
-#include "state_mgr.h"
-
 #include <FreeRTOS.h>
+#include <can.h>
+#include <gio.h>
+#include <het.h>
+#include <i2c.h>
 #include <os_task.h>
-
+#include <sci.h>
+#include <spi.h>
 #include <sys_common.h>
 #include <sys_core.h>
-#include <gio.h>
-#include <sci.h>
-#include <i2c.h>
-#include <spi.h>
-#include <can.h>
-#include <het.h>
+
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_reset.h"
+#include "obc_scheduler_config.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
+#include "state_mgr.h"
 
 // This is the stack canary. It should never be overwritten.
 

--- a/obc/app/drivers/arducam/arducam.c
+++ b/obc/app/drivers/arducam/arducam.c
@@ -1,9 +1,8 @@
 #include "arducam.h"
 
-#include "ov5642_config.h"
-
-#include "obc_spi_io.h"
 #include "obc_board_config.h"
+#include "obc_spi_io.h"
+#include "ov5642_config.h"
 #include "spi.h"
 
 // Constants

--- a/obc/app/drivers/arducam/arducam.h
+++ b/obc/app/drivers/arducam/arducam.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "ov5642_config.h"
-#include "ov5642.h"
-
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "obc_errors.h"
 #include "obc_logging.h"
+#include "ov5642.h"
+#include "ov5642_config.h"
 
 /**
  * @enum	camera_t

--- a/obc/app/drivers/arducam/ov5642.c
+++ b/obc/app/drivers/arducam/ov5642.c
@@ -1,10 +1,10 @@
 #include "ov5642.h"
 
-#include "ov5642_config.h"
-#include "obc_logging.h"
-#include "obc_i2c_io.h"
-
 #include <os_semphr.h>
+
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "ov5642_config.h"
 
 // Camera Img Sensor (I2C) defines
 #define CAM_I2C_ADDR 0x3C

--- a/obc/app/drivers/arducam/ov5642.h
+++ b/obc/app/drivers/arducam/ov5642.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief Initializes mutex for ov5642

--- a/obc/app/drivers/bd621x/bd621x.c
+++ b/obc/app/drivers/bd621x/bd621x.c
@@ -1,10 +1,10 @@
-#include "het.h"
-
 #include "bd621x.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
 
 #include <stdlib.h>
+
+#include "het.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 // Datasheet reference: https://fscdn.rohm.com/en/products/databook/datasheet/ic/motor/dc/bd621x-e.pdf
 

--- a/obc/app/drivers/bd621x/bd621x.h
+++ b/obc/app/drivers/bd621x/bd621x.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "obc_errors.h"
 #include "het.h"
+#include "obc_errors.h"
 
 /**
 * @struct DC_motor_t

--- a/obc/app/drivers/cc1120/cc1120.c
+++ b/obc/app/drivers/cc1120/cc1120.c
@@ -1,8 +1,9 @@
 #include "cc1120.h"
+
 #include "cc1120_defs.h"
 #include "cc1120_mcu.h"
-#include "obc_logging.h"
 #include "obc_board_config.h"
+#include "obc_logging.h"
 
 #define READ_BIT 1 << 7
 #define BURST_BIT 1 << 6

--- a/obc/app/drivers/cc1120/cc1120.h
+++ b/obc/app/drivers/cc1120/cc1120.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+
 #include "obc_errors.h"
 
 // See chapter 8.5 in the datasheet

--- a/obc/app/drivers/cc1120/cc1120_mcu.c
+++ b/obc/app/drivers/cc1120/cc1120_mcu.c
@@ -1,4 +1,5 @@
 #include "cc1120_mcu.h"
+
 #include "obc_spi_io.h"
 
 static const spiDAT1_t spiConfig = {.CS_HOLD = false, .WDEL = false, .DFSEL = CC1120_SPI_FMT, .CSNR = SPI_CS_NONE};

--- a/obc/app/drivers/cc1120/cc1120_mcu.h
+++ b/obc/app/drivers/cc1120/cc1120_mcu.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "obc_errors.h"
 #include "obc_logging.h"
 #include "obc_spi_io.h"
-#include <stdint.h>
 
 #define CC1120_SPI_REG spiREG4
 #define CC1120_SPI_PORT spiPORT4

--- a/obc/app/drivers/ds3232/ds3232_mz.c
+++ b/obc/app/drivers/ds3232/ds3232_mz.c
@@ -1,11 +1,12 @@
 #include "ds3232_mz.h"
-#include "obc_i2c_io.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_bit_ops.h"
 
-#include <stdint.h>
 #include <gio.h>
+#include <stdint.h>
+
+#include "obc_bit_ops.h"
+#include "obc_errors.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
 
 #define DS3232_I2C_ADDRESS 0x68U
 

--- a/obc/app/drivers/ds3232/ds3232_mz.h
+++ b/obc/app/drivers/ds3232/ds3232_mz.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 // RTC year is 0-99, so we need to add this offset to get the actual year
 #define RTC_YEAR_OFFSET 2000

--- a/obc/app/drivers/fram/fm25v20a.c
+++ b/obc/app/drivers/fram/fm25v20a.c
@@ -1,13 +1,14 @@
-#include <stdlib.h>
 #include "fm25v20a.h"
-#include <FreeRTOS.h>
 
-#include "spi.h"
-#include "obc_spi_io.h"
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_board_config.h"
+#include <FreeRTOS.h>
+#include <stdlib.h>
 #include <sys_common.h>
+
+#include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_spi_io.h"
+#include "spi.h"
 
 // SPI values
 static spiDAT1_t framSPIDataFmt = {.CS_HOLD = 0, .CSNR = SPI_CS_NONE, .DFSEL = FRAM_spiFMT, .WDEL = 0};

--- a/obc/app/drivers/fram/fm25v20a.h
+++ b/obc/app/drivers/fram/fm25v20a.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
+
 #include "obc_errors.h"
 
 // FM25V20A LIMITS

--- a/obc/app/drivers/lm75bd/lm75bd.c
+++ b/obc/app/drivers/lm75bd/lm75bd.c
@@ -1,11 +1,12 @@
 #include "lm75bd.h"
+
+#include <math.h>
+#include <stdint.h>
+
+#include "obc_assert.h"
+#include "obc_errors.h"
 #include "obc_i2c_io.h"
 #include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_assert.h"
-
-#include <stdint.h>
-#include <math.h>
 
 #define LM75BD_I2C_BASE_ADDR 0x9U
 

--- a/obc/app/drivers/lm75bd/lm75bd.h
+++ b/obc/app/drivers/lm75bd/lm75bd.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <stdint.h>
+
+#include "obc_errors.h"
 
 /* LM75BD I2C Device Address */
 #define LM75BD_OBC_I2C_ADDR 0x4FU /* (0x9U << 3) | 0x7 */

--- a/obc/app/drivers/max5360/max5360.c
+++ b/obc/app/drivers/max5360/max5360.c
@@ -1,9 +1,10 @@
 #include "max5360.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_i2c_io.h"
 
 #include <stdint.h>
+
+#include "obc_errors.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
 
 #define DAC_ADDRESS 0x60U
 #define DAC_VREF_VALUE 2U

--- a/obc/app/drivers/rffm6404/rffm6404.c
+++ b/obc/app/drivers/rffm6404/rffm6404.c
@@ -1,8 +1,8 @@
-#include "obc_errors.h"
-#include "obc_logging.h"
 #include "gio.h"
 #include "max5360.h"
 #include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 /* See Page 4 of the RFFM6404 datasheet for truth table explaining necessary pin values for each mode */
 

--- a/obc/app/drivers/rm46/obc_adc.c
+++ b/obc/app/drivers/rm46/obc_adc.c
@@ -1,13 +1,14 @@
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "adc.h"
-#include "reg_adc.h"
 #include "obc_adc.h"
 
 #include <FreeRTOS.h>
 #include <os_portmacro.h>
 #include <os_semphr.h>
 #include <os_task.h>
+
+#include "adc.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "reg_adc.h"
 
 static SemaphoreHandle_t adcConversionMutex = NULL;
 static StaticSemaphore_t adcConversionMutexBuffer;

--- a/obc/app/drivers/rm46/obc_adc.h
+++ b/obc/app/drivers/rm46/obc_adc.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "adc.h"
-#include "reg_adc.h"
-
 #include <FreeRTOS.h>
 #include <os_portmacro.h>
 #include <os_semphr.h>
 #include <os_task.h>
-
 #include <stdint.h>
+
+#include "adc.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "reg_adc.h"
 
 typedef enum { ADC_MODULE_1 = 0U, ADC_MODULE_2 = 1U } adc_module_t;
 

--- a/obc/app/drivers/rm46/obc_digital_watchdog.c
+++ b/obc/app/drivers/rm46/obc_digital_watchdog.c
@@ -1,10 +1,11 @@
 #include "obc_digital_watchdog.h"
-#include "obc_assert.h"
 
-#include <system.h>
 #include <reg_rti.h>
 #include <rti.h>
 #include <stdint.h>
+#include <system.h>
+
+#include "obc_assert.h"
 
 // Watchdog is fed by writing these two values to the WDKEY register
 #define RESET_DWD_CMD1 0xE51AUL

--- a/obc/app/drivers/rm46/obc_dma.c
+++ b/obc/app/drivers/rm46/obc_dma.c
@@ -1,7 +1,8 @@
 #include "obc_dma.h"
-#include "obc_spi_dma.h"
 
 #include <sys_dma.h>
+
+#include "obc_spi_dma.h"
 
 void dmaGroupANotification(dmaInterrupt_t inttype, uint32 channel) {
   switch (inttype) {

--- a/obc/app/drivers/rm46/obc_exception_handlers.c
+++ b/obc/app/drivers/rm46/obc_exception_handlers.c
@@ -1,9 +1,9 @@
-#include <FreeRTOSConfig.h>
 #include <FreeRTOS.h>
+#include <FreeRTOSConfig.h>
 
-#include "os_task.h"
-#include "obc_reset.h"
 #include "obc_logging.h"
+#include "obc_reset.h"
+#include "os_task.h"
 
 void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
   LOG_FATAL_FROM_ISR("***********************STACK OVERFLOW DETECTED!!!!!!***********************");

--- a/obc/app/drivers/rm46/obc_gio_ctrl.c
+++ b/obc/app/drivers/rm46/obc_gio_ctrl.c
@@ -1,8 +1,7 @@
+#include "alarm_handler.h"
+#include "cc1120_txrx.h"
 #include "gio.h"
 #include "hal_stdtypes.h"
-
-#include "cc1120_txrx.h"
-#include "alarm_handler.h"
 #include "obc_board_config.h"
 #include "tpl5010.h"
 

--- a/obc/app/drivers/rm46/obc_het_ctrl.c
+++ b/obc/app/drivers/rm46/obc_het_ctrl.c
@@ -1,9 +1,8 @@
-#include "het.h"
-#include "hal_stdtypes.h"
+#include <stdint.h>
 
 #include "cc1120_txrx.h"
+#include "hal_stdtypes.h"
+#include "het.h"
 #include "obc_board_config.h"
-
-#include <stdint.h>
 
 void edgeNotification(hetBASE_t* hetREG, uint32 edge) {}

--- a/obc/app/drivers/rm46/obc_i2c_io.c
+++ b/obc/app/drivers/rm46/obc_i2c_io.c
@@ -1,15 +1,15 @@
 #include "obc_i2c_io.h"
-#include "obc_errors.h"
-#include "obc_assert.h"
-#include "obc_logging.h"
 
 #include <FreeRTOS.h>
+#include <i2c.h>
 #include <os_portmacro.h>
 #include <os_semphr.h>
 #include <os_task.h>
-
-#include <i2c.h>
 #include <sys_common.h>
+
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 // The I2C bus to use for the OBC
 #define I2C_REG i2cREG1

--- a/obc/app/drivers/rm46/obc_i2c_io.h
+++ b/obc/app/drivers/rm46/obc_i2c_io.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
-
 #include <i2c.h>
 #include <os_projdefs.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief Initialize the I2C bus mutex

--- a/obc/app/drivers/rm46/obc_reset.c
+++ b/obc/app/drivers/rm46/obc_reset.c
@@ -1,6 +1,7 @@
 #include "obc_reset.h"
-#include "reg_system.h"
+
 #include "obc_privilege.h"
+#include "reg_system.h"
 
 #define RESET_SYSTEM_MASK (1 << 15)
 

--- a/obc/app/drivers/rm46/obc_sci_io.c
+++ b/obc/app/drivers/rm46/obc_sci_io.c
@@ -1,18 +1,18 @@
 #include "obc_sci_io.h"
-#include "obc_assert.h"
-#include "obc_board_config.h"
-#include "obc_errors.h"
 
 #include <FreeRTOS.h>
 #include <FreeRTOSConfig.h>
 #include <os_portmacro.h>
 #include <os_semphr.h>
 #include <os_task.h>
-
 #include <sci.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#include "obc_assert.h"
+#include "obc_board_config.h"
+#include "obc_errors.h"
 
 static SemaphoreHandle_t sciReadMutex = NULL;
 static SemaphoreHandle_t sciWriteMutex = NULL;

--- a/obc/app/drivers/rm46/obc_sci_io.h
+++ b/obc/app/drivers/rm46/obc_sci_io.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <sci.h>
 #include <stdint.h>
+
+#include "obc_errors.h"
 
 #ifndef OBC_UART_BAUD_RATE
 #define OBC_UART_BAUD_RATE 115200

--- a/obc/app/drivers/rm46/obc_spi_dma.c
+++ b/obc/app/drivers/rm46/obc_spi_dma.c
@@ -1,14 +1,15 @@
 #include "obc_spi_dma.h"
-#include "spi.h"
-#include "sys_dma.h"
+
+#include <FreeRTOS.h>
+#include <os_semphr.h>
+
+#include "obc_dma.h"
 #include "obc_errors.h"
 #include "obc_logging.h"
 #include "obc_privilege.h"
 #include "obc_spi_io.h"
-#include "obc_dma.h"
-
-#include <FreeRTOS.h>
-#include <os_semphr.h>
+#include "spi.h"
+#include "sys_dma.h"
 
 #define SPI_NOTIFICATION_DMA_REQ 0x10000
 

--- a/obc/app/drivers/rm46/obc_spi_dma.h
+++ b/obc/app/drivers/rm46/obc_spi_dma.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "obc_errors.h"
 #include "spi.h"
-
-#include <stdint.h>
 
 /**
  * @brief initalizes DMA for facilitating spi transfers for spiReg

--- a/obc/app/drivers/rm46/obc_spi_io.c
+++ b/obc/app/drivers/rm46/obc_spi_io.c
@@ -1,15 +1,14 @@
 #include "obc_spi_io.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
 
 #include <FreeRTOS.h>
-#include <os_task.h>
-#include <os_semphr.h>
-
 #include <gio.h>
+#include <os_semphr.h>
+#include <os_task.h>
 #include <spi.h>
-
 #include <stdint.h>
+
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 // This includes SPI2 which isn't available on the RM46 PGE package
 #define NUM_SPI_PORTS 5

--- a/obc/app/drivers/rm46/obc_spi_io.h
+++ b/obc/app/drivers/rm46/obc_spi_io.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "obc_errors.h"
-
+#include <FreeRTOS.h>
+#include <gio.h>
+#include <os_semphr.h>
+#include <spi.h>
 #include <stdint.h>
 
-#include <spi.h>
-#include <gio.h>
-#include <FreeRTOS.h>
-#include <os_semphr.h>
+#include "obc_errors.h"
 
 #define DEASSERT_RETURN_IF_ERROR_CODE(_spiPort, _csNum, _ret) \
   do {                                                        \

--- a/obc/app/drivers/sdcard/sdc_bdev.c
+++ b/obc/app/drivers/sdcard/sdc_bdev.c
@@ -1,19 +1,17 @@
-#include <stdint.h>
-#include <stdbool.h>
-
 #include <FreeRTOS.h>
-#include <os_task.h>
-
-#include <sys_common.h>
 #include <gio.h>
+#include <os_task.h>
 #include <spi.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys_common.h>
 
-#include "sdc_diskio.h"
-#include "sdc_rm46.h"
-#include "obc_spi_io.h"
-#include "obc_logging.h"
 #include "obc_assert.h"
 #include "obc_board_config.h"
+#include "obc_logging.h"
+#include "obc_spi_io.h"
+#include "sdc_diskio.h"
+#include "sdc_rm46.h"
 
 /* This driver logs errors. If the logging output is set to the
    microSD card, this driver will log errors to itself, which

--- a/obc/app/drivers/tpl5010/tpl5010.c
+++ b/obc/app/drivers/tpl5010/tpl5010.c
@@ -1,8 +1,8 @@
 #ifdef OBC_REVISION_2
 
 #include "tpl5010.h"
-#include "gio.h"
 
+#include "gio.h"
 #include "obc_board_config.h"
 
 #define DONE_SIGNAL_ON 1

--- a/obc/app/drivers/vn100/vn100.c
+++ b/obc/app/drivers/vn100/vn100.c
@@ -1,13 +1,14 @@
-#include "obc_errors.h"
-#include "obc_board_config.h"
-#include "obc_logging.h"
-#include "obc_sci_io.h"
 #include "vn100.h"
 
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_sci_io.h"
 
 #define VN100_DEFAULT_BAUDRATE 115200U
 #define MAX_SEND_SIZE 120U

--- a/obc/app/drivers/vn100/vn100.h
+++ b/obc/app/drivers/vn100/vn100.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "obc_errors.h"
 #include "vn100_binary_parsing.h"
-
-#include <stdint.h>
 
 /* To access the user manual for VN-100 click here --> https://geo-matching.com/media/migrationpiwnum.pdf */
 

--- a/obc/app/drivers/vn100/vn100_binary_parsing.c
+++ b/obc/app/drivers/vn100/vn100_binary_parsing.c
@@ -1,14 +1,14 @@
-#include "obc_errors.h"
-#include "obc_gs_crc.h"
-
 #include "vn100_binary_parsing.h"
-#include "data_unpack_utils.h"
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
-#include <stdio.h>
+
+#include "data_unpack_utils.h"
+#include "obc_errors.h"
+#include "obc_gs_crc.h"
 
 /* ------------------------------------------- Packet Error Checking ------------------------------------*/
 #define DEFAULT_SYNC_BYTE 0xFA

--- a/obc/app/drivers/vn100/vn100_binary_parsing.h
+++ b/obc/app/drivers/vn100/vn100_binary_parsing.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <stdint.h>
 #include <stdlib.h>
+
+#include "obc_errors.h"
 
 /* -------------------------------------- Packet structure Byte Sizes -------------------------- */
 #define VN100_BINARY_HEADER_SIZE 4U

--- a/obc/app/modules/alarm_mgr/alarm_handler.c
+++ b/obc/app/modules/alarm_mgr/alarm_handler.c
@@ -1,20 +1,21 @@
 #include "alarm_handler.h"
-#include "ds3232_mz.h"
-#include "obc_gs_commands_response.h"
-#include "obc_gs_fec.h"
-#include "obc_scheduler_config.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_time.h"
-#include "obc_time_utils.h"
-#include "obc_persistent.h"
-#include "obc_assert.h"
-#include "command_manager.h"
 
 #include <FreeRTOS.h>
-#include <os_task.h>
 #include <os_queue.h>
+#include <os_task.h>
 #include <sys_common.h>
+
+#include "command_manager.h"
+#include "ds3232_mz.h"
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_gs_commands_response.h"
+#include "obc_gs_fec.h"
+#include "obc_logging.h"
+#include "obc_persistent.h"
+#include "obc_scheduler_config.h"
+#include "obc_time.h"
+#include "obc_time_utils.h"
 
 #define ALARM_QUEUE_SIZE 24U
 #define ALARM_HANDLER_QUEUE_LENGTH 64U

--- a/obc/app/modules/alarm_mgr/alarm_handler.h
+++ b/obc/app/modules/alarm_mgr/alarm_handler.h
@@ -2,8 +2,8 @@
 
 #include <stdint.h>
 
-#include "obc_errors.h"
 #include "command.h"
+#include "obc_errors.h"
 #include "obc_time.h"
 
 // Alarm handler event IDs

--- a/obc/app/modules/camera_mgr/image_processing.h
+++ b/obc/app/modules/camera_mgr/image_processing.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <stddef.h>
 #include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief A struct to store an image

--- a/obc/app/modules/camera_mgr/payload_manager.c
+++ b/obc/app/modules/camera_mgr/payload_manager.c
@@ -1,14 +1,14 @@
 #include "payload_manager.h"
-#include "obc_errors.h"
-#include "obc_scheduler_config.h"
 
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
 #include <os_task.h>
-
 #include <sys_common.h>
-#include <gio.h>
+
+#include "obc_errors.h"
+#include "obc_scheduler_config.h"
 
 static QueueHandle_t payloadQueueHandle = NULL;
 static StaticQueue_t payloadQueue;

--- a/obc/app/modules/camera_mgr/payload_manager.h
+++ b/obc/app/modules/camera_mgr/payload_manager.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <sys_common.h>
+
+#include "obc_errors.h"
 
 /**
  * @enum	payload_event_id_t

--- a/obc/app/modules/command_mgr/command_callbacks.c
+++ b/obc/app/modules/command_mgr/command_callbacks.c
@@ -1,21 +1,21 @@
-#include "obc_gs_command_data.h"
-#include "obc_gs_command_id.h"
-#include "obc_i2c_io.h"
-#include "obc_reset.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_time.h"
-#include "obc_time_utils.h"
-#include "downlink_encoder.h"
-#include "os_portmacro.h"
-#include "os_projdefs.h"
-#include "telemetry_manager.h"
-#include "command.h"
-#include "obc_general_util.h"
-
 #include <redposix.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "command.h"
+#include "downlink_encoder.h"
+#include "obc_errors.h"
+#include "obc_general_util.h"
+#include "obc_gs_command_data.h"
+#include "obc_gs_command_id.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_reset.h"
+#include "obc_time.h"
+#include "obc_time_utils.h"
+#include "os_portmacro.h"
+#include "os_projdefs.h"
+#include "telemetry_manager.h"
 
 static obc_error_code_t execObcResetCmdCallback(cmd_msg_t *cmd, uint8_t *responseData, uint8_t *responseDataLen) {
   if (cmd == NULL || responseData == NULL || responseDataLen == NULL) {

--- a/obc/app/modules/command_mgr/command_manager.c
+++ b/obc/app/modules/command_mgr/command_manager.c
@@ -1,21 +1,22 @@
+#include "command_manager.h"
+
+#include <FreeRTOS.h>
+#include <os_queue.h>
+#include <os_task.h>
+#include <stdint.h>
+#include <sys_common.h>
+
 #include "alarm_handler.h"
 #include "command.h"
-#include "command_manager.h"
 #include "downlink_encoder.h"
-#include "obc_gs_command_data.h"
 #include "obc_errors.h"
+#include "obc_gs_command_data.h"
 #include "obc_gs_command_id.h"
 #include "obc_gs_commands_response.h"
 #include "obc_gs_commands_response_pack.h"
 #include "obc_gs_errors.h"
 #include "obc_gs_fec.h"
 #include "obc_logging.h"
-
-#include <FreeRTOS.h>
-#include <stdint.h>
-#include <sys_common.h>
-#include <os_task.h>
-#include <os_queue.h>
 
 #define COMMAND_QUEUE_LENGTH 25UL
 #define COMMAND_QUEUE_ITEM_SIZE sizeof(cmd_msg_t)

--- a/obc/app/modules/comms_link_mgr/cc1120_txrx.c
+++ b/obc/app/modules/comms_link_mgr/cc1120_txrx.c
@@ -1,19 +1,18 @@
 #include "cc1120_txrx.h"
-#include "obc_logging.h"
-#include "cc1120_mcu.h"
-#include "cc1120.h"
-#include "cc1120_defs.h"
-#include "obc_math.h"
-#include "obc_board_config.h"
-
-#include "uplink_decoder.h"
 
 #include <FreeRTOS.h>
-#include <os_semphr.h>
-#include <sys_common.h>
 #include <FreeRTOSConfig.h>
-
+#include <os_semphr.h>
 #include <stdbool.h>
+#include <sys_common.h>
+
+#include "cc1120.h"
+#include "cc1120_defs.h"
+#include "cc1120_mcu.h"
+#include "obc_board_config.h"
+#include "obc_logging.h"
+#include "obc_math.h"
+#include "uplink_decoder.h"
 
 #define COMMS_MAX_UPLINK_BYTES \
   1000U  // Maximum amount of bytes we will currently be uplinking at a time (should be updated in the future)

--- a/obc/app/modules/comms_link_mgr/cc1120_txrx.h
+++ b/obc/app/modules/comms_link_mgr/cc1120_txrx.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
-
 #include <FreeRTOS.h>
 #include <os_semphr.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief Initializes all of the semaphores that will be used by cc1120Send and cc1120Receive

--- a/obc/app/modules/comms_link_mgr/comms_manager.c
+++ b/obc/app/modules/comms_link_mgr/comms_manager.c
@@ -1,4 +1,7 @@
 #include "comms_manager.h"
+
+#include <stdint.h>
+
 #include "cc1120.h"
 #include "cc1120_txrx.h"
 #include "downlink_encoder.h"
@@ -20,20 +23,17 @@
 #include "telemetry_fs_utils.h"
 #include "telemetry_manager.h"
 #include "uplink_decoder.h"
-#include <stdint.h>
 
 #if COMMS_PHY == COMMS_PHY_UART
 #include "obc_sci_io.h"
 #endif
 
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
 #include <os_task.h>
-
 #include <redposix.h>
-
-#include <gio.h>
 #include <sys_common.h>
 
 #define COMMS_MAX_DOWNLINK_FRAMES 1000U

--- a/obc/app/modules/comms_link_mgr/comms_manager.h
+++ b/obc/app/modules/comms_link_mgr/comms_manager.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "obc_errors.h"
-#include "telemetry_manager.h"
-#include "obc_gs_ax25.h"
-
 #include <FreeRTOS.h>
 #include <os_semphr.h>
 #include <sys_common.h>
+
+#include "obc_errors.h"
+#include "obc_gs_ax25.h"
+#include "telemetry_manager.h"
 
 #define MAX_DOWNLINK_TELEM_BUFFER_SIZE 1U
 

--- a/obc/app/modules/comms_link_mgr/downlink_encoder.c
+++ b/obc/app/modules/comms_link_mgr/downlink_encoder.c
@@ -1,29 +1,27 @@
 #include "downlink_encoder.h"
-#include "cc1120_txrx.h"
-#include "obc_board_config.h"
-#include "obc_gs_ax25.h"
-#include "obc_gs_commands_response.h"
-#include "obc_gs_fec.h"
-
-#include "obc_gs_telemetry_pack.h"
-#include "obc_sci_io.h"
-#include "telemetry_fs_utils.h"
-#include "telemetry_manager.h"
-
-#include "comms_manager.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_reliance_fs.h"
-#include "obc_scheduler_config.h"
 
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
 #include <os_task.h>
-
-#include <gio.h>
 #include <stdint.h>
 #include <sys_common.h>
+
+#include "cc1120_txrx.h"
+#include "comms_manager.h"
+#include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_gs_ax25.h"
+#include "obc_gs_commands_response.h"
+#include "obc_gs_fec.h"
+#include "obc_gs_telemetry_pack.h"
+#include "obc_logging.h"
+#include "obc_reliance_fs.h"
+#include "obc_scheduler_config.h"
+#include "obc_sci_io.h"
+#include "telemetry_fs_utils.h"
+#include "telemetry_manager.h"
 
 #define COMMS_TELEM_ENCODE_QUEUE_LENGTH 2U
 #define COMMS_TELEM_ENCODE_QUEUE_ITEM_SIZE sizeof(encode_event_t)  // Size of the telemetry batch ID

--- a/obc/app/modules/comms_link_mgr/downlink_encoder.h
+++ b/obc/app/modules/comms_link_mgr/downlink_encoder.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
-#include "obc_errors.h"
 #include "comms_manager.h"
+#include "obc_errors.h"
 
 typedef enum { DOWNLINK_TELEMETRY_FILE, DOWNLINK_DATA_BUFFER, DOWNLINK_CMD_RESPONSE } encode_event_id_t;
 

--- a/obc/app/modules/comms_link_mgr/uplink_decoder.c
+++ b/obc/app/modules/comms_link_mgr/uplink_decoder.c
@@ -1,4 +1,18 @@
 #include "uplink_decoder.h"
+
+#include <FreeRTOS.h>
+#include <gio.h>
+#include <os_portmacro.h>
+#include <os_queue.h>
+#include <os_semphr.h>
+#include <os_task.h>
+#include <os_timer.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys_common.h>
+
 #include "cc1120.h"
 #include "cc1120_defs.h"
 #include "cc1120_txrx.h"
@@ -15,20 +29,6 @@
 #include "obc_logging.h"
 #include "obc_scheduler_config.h"
 #include "obc_sci_io.h"
-
-#include <FreeRTOS.h>
-#include <gio.h>
-#include <os_portmacro.h>
-#include <os_queue.h>
-#include <os_semphr.h>
-#include <os_task.h>
-#include <os_timer.h>
-#include <sys_common.h>
-
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
 
 // decode data queue length should be double TXRX_INTERRUPT_THRESHOLD for safety
 // to avoid cc1120 getting blocked can be reduced later depending on memory

--- a/obc/app/modules/comms_link_mgr/uplink_decoder.h
+++ b/obc/app/modules/comms_link_mgr/uplink_decoder.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief parses the completely decoded data and sends it to the command manager and detects end of transmission

--- a/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
+++ b/obc/app/modules/digital_watchdog_mgr/digital_watchdog_mgr.c
@@ -1,12 +1,12 @@
 #include "digital_watchdog_mgr.h"
-#include "obc_digital_watchdog.h"
-#include "obc_privilege.h"
-#include "obc_scheduler_config.h"
-#include "obc_logging.h"
-
-#include <system.h>
 
 #include <stdint.h>
+#include <system.h>
+
+#include "obc_digital_watchdog.h"
+#include "obc_logging.h"
+#include "obc_privilege.h"
+#include "obc_scheduler_config.h"
 
 // Must feed the watchdog before the timeout period expires
 // This value should provide some margin

--- a/obc/app/modules/eps_mgr/eps_manager.c
+++ b/obc/app/modules/eps_mgr/eps_manager.c
@@ -1,13 +1,13 @@
 #include "eps_manager.h"
-#include "obc_scheduler_config.h"
 
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
 #include <os_task.h>
-
 #include <sys_common.h>
-#include <gio.h>
+
+#include "obc_scheduler_config.h"
 
 static QueueHandle_t epsQueueHandle = NULL;
 static StaticQueue_t epsQueue;

--- a/obc/app/modules/eps_mgr/eps_manager.h
+++ b/obc/app/modules/eps_mgr/eps_manager.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <sys_common.h>
+
+#include "obc_errors.h"
 
 /**
  * @enum	eps_event_id_t

--- a/obc/app/modules/gnc_mgr/gnc_manager.c
+++ b/obc/app/modules/gnc_mgr/gnc_manager.c
@@ -1,24 +1,24 @@
-#include "obc_digital_watchdog.h"
-#include "digital_watchdog_mgr.h"
-#include "obc_errors.h"
-#include "obc_scheduler_config.h"
-#include "obc_print.h"
-#include "obc_logging.h"
-#include "obc_general_util.h"
 #include "gnc_manager.h"
-#include "attitude_control.h"
-#include "attitude_determination_and_vehi.h"
-#include "onboard_env_modelling.h"
-#include "vn100.h"
-#include "bd621x.h"
 
 #include <FreeRTOS.h>
+#include <gio.h>
+#include <math.h>
 #include <os_portmacro.h>
 #include <os_task.h>
 #include <sys_common.h>
-#include <gio.h>
 
-#include <math.h>
+#include "attitude_control.h"
+#include "attitude_determination_and_vehi.h"
+#include "bd621x.h"
+#include "digital_watchdog_mgr.h"
+#include "obc_digital_watchdog.h"
+#include "obc_errors.h"
+#include "obc_general_util.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_scheduler_config.h"
+#include "onboard_env_modelling.h"
+#include "vn100.h"
 
 #define DEFAULT_GNC_TASK_PERIOD_MS 50 /* 50ms period or 20Hz */
 #define MAX_GNC_TASK_PERIOD_MS 100

--- a/obc/app/modules/gnc_mgr/gnc_manager.h
+++ b/obc/app/modules/gnc_mgr/gnc_manager.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief Set the GNC task period. Will be used for when we want to run GNC tasks more or less frequently (QEYnet

--- a/obc/app/modules/health_collector/health_collector.c
+++ b/obc/app/modules/health_collector/health_collector.c
@@ -1,14 +1,15 @@
 #include "health_collector.h"
-#include "lm75bd.h"
-#include "obc_time.h"
-#include "telemetry_manager.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_scheduler_config.h"
 
 #include <FreeRTOS.h>
 #include <os_task.h>
 #include <sys_common.h>
+
+#include "lm75bd.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_scheduler_config.h"
+#include "obc_time.h"
+#include "telemetry_manager.h"
 
 #define HEALTH_COLLECTION_PERIOD_MS 60000UL
 

--- a/obc/app/modules/logger/logger.c
+++ b/obc/app/modules/logger/logger.c
@@ -1,19 +1,19 @@
 #include "logger.h"
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_print.h"
-#include "obc_time.h"
 
 #include <FreeRTOS.h>
 #include <FreeRTOSConfig.h>
-#include <sys_common.h>
 #include <os_queue.h>
 #include <redposix.h>
-
-#include <string.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys_common.h>
+
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_time.h"
 
 #define LOG_FILE_NAME "log.log"
 

--- a/obc/app/modules/logger/logger.h
+++ b/obc/app/modules/logger/logger.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <stdio.h>
+
+#include "ds3232_mz.h"
 #include "obc_errors.h"
 #include "obc_logging.h"
-#include "ds3232_mz.h"
-
-#include <stdio.h>
 
 // launchpad doesn't have RTC so we should not try to add timestamps
 #ifdef RM46_LAUNCHPAD

--- a/obc/app/modules/state_mgr/state_mgr.c
+++ b/obc/app/modules/state_mgr/state_mgr.c
@@ -1,23 +1,23 @@
 #include "state_mgr.h"
-#include "comms_manager.h"  // for comms_state_t
-#include "obc_board_config.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_reliance_fs.h"
-#include "obc_scheduler_config.h"
-#include "obc_time.h"
-
-#include "fm25v20a.h"
-#include "lm75bd.h"  // TODO: Handle within thermal manager
-#include "cc1120_txrx.h"
-#include "cc1120.h"
-#include "arducam.h"
 
 #include <FreeRTOS.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
 #include <os_task.h>
 #include <sys_common.h>
+
+#include "arducam.h"
+#include "cc1120.h"
+#include "cc1120_txrx.h"
+#include "comms_manager.h"  // for comms_state_t
+#include "fm25v20a.h"
+#include "lm75bd.h"  // TODO: Handle within thermal manager
+#include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_reliance_fs.h"
+#include "obc_scheduler_config.h"
+#include "obc_time.h"
 
 #if defined(DEBUG) && !defined(OBC_REVISION_2)
 #include <gio.h>

--- a/obc/app/modules/state_mgr/state_mgr.h
+++ b/obc/app/modules/state_mgr/state_mgr.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "obc_errors.h"
-
 #include <sys_common.h>
+
+#include "obc_errors.h"
 
 /**
  * @enum	state_mgr_event_id_t

--- a/obc/app/modules/task_stats_collector/task_stats_collector.c
+++ b/obc/app/modules/task_stats_collector/task_stats_collector.c
@@ -1,9 +1,10 @@
 #if ENABLE_TASK_STATS_COLLECTOR == 1
 #include "task_stats_collector.h"
-#include "obc_scheduler_config.h"
+
+#include "obc_logging.h"
 #include "obc_print.h"
 #include "obc_privilege.h"
-#include "obc_logging.h"
+#include "obc_scheduler_config.h"
 
 #define TASK_STATS_BUFFER_SIZE 1000U
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY

--- a/obc/app/modules/telemetry_mgr/telemetry_fs_utils.c
+++ b/obc/app/modules/telemetry_mgr/telemetry_fs_utils.c
@@ -1,15 +1,15 @@
 #include "telemetry_fs_utils.h"
-#include "telemetry_manager.h"
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_assert.h"
-#include "obc_reliance_fs.h"
 
 #include <redposix.h>
-
-#include <stdio.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_reliance_fs.h"
+#include "telemetry_manager.h"
 
 obc_error_code_t mkTelemetryDir(void) {
   obc_error_code_t errCode;

--- a/obc/app/modules/telemetry_mgr/telemetry_fs_utils.h
+++ b/obc/app/modules/telemetry_mgr/telemetry_fs_utils.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "obc_errors.h"
 #include "telemetry_manager.h"
-
-#include <stdint.h>
-#include <stddef.h>
 
 /* Telemetry file path config */
 #define TELEMETRY_FILE_DIRECTORY "/telemetry/"

--- a/obc/app/modules/telemetry_mgr/telemetry_manager.c
+++ b/obc/app/modules/telemetry_mgr/telemetry_manager.c
@@ -1,25 +1,24 @@
 #include "telemetry_manager.h"
-#include "telemetry_fs_utils.h"
-#include "comms_manager.h"
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_assert.h"
-#include "obc_scheduler_config.h"
-#include "downlink_encoder.h"
 
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_portmacro.h>
 #include <os_queue.h>
-#include <os_task.h>
 #include <os_semphr.h>
-#include <sys_common.h>
-#include <gio.h>
-
+#include <os_task.h>
 #include <redposix.h>
-
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys_common.h>
+
+#include "comms_manager.h"
+#include "downlink_encoder.h"
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_scheduler_config.h"
+#include "telemetry_fs_utils.h"
 
 /* Telemetry data queue config */
 #define TELEMETRY_DATA_QUEUE_LENGTH 128U

--- a/obc/app/modules/telemetry_mgr/telemetry_manager.h
+++ b/obc/app/modules/telemetry_mgr/telemetry_manager.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "obc_errors.h"
 #include "obc_gs_telemetry_data.h"
-
-#include <stdint.h>
-#include <stddef.h>
 
 /**
  * @brief	Adds a telemetry data point to the telemetry queue

--- a/obc/app/modules/timekeeper/timekeeper.c
+++ b/obc/app/modules/timekeeper/timekeeper.c
@@ -1,16 +1,17 @@
 #include "timekeeper.h"
-#include "obc_time.h"
-#include "obc_errors.h"
-#include "obc_assert.h"
-#include "obc_logging.h"
-#include "obc_persistent.h"
-#include "obc_scheduler_config.h"
-#include "ds3232_mz.h"
 
 #include <FreeRTOS.h>
 #include <os_task.h>
 #include <os_timer.h>
 #include <sys_common.h>
+
+#include "ds3232_mz.h"
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_persistent.h"
+#include "obc_scheduler_config.h"
+#include "obc_time.h"
 
 #define LOCAL_TIME_SYNC_PERIOD_S 60UL
 

--- a/obc/app/reliance_edge/bdev/bdev.c
+++ b/obc/app/reliance_edge/bdev/bdev.c
@@ -26,9 +26,9 @@
 /** @file
     @brief Implements the block device abstraction of the file system.
 */
+#include <redbdev.h>
 #include <redfs.h>
 #include <redvolume.h>
-#include <redbdev.h>
 
 BDEVINFO gaRedBdevInfo[REDCONF_VOLUME_COUNT];
 

--- a/obc/app/reliance_edge/core/driver/blockio.c
+++ b/obc/app/reliance_edge/core/driver/blockio.c
@@ -36,9 +36,9 @@
     drivers that are sometimes found in the IoT world, where one operation may
     fail but the next may still succeed.
 */
-#include <redfs.h>
-#include <redcore.h>
 #include <redbdev.h>
+#include <redcore.h>
+#include <redfs.h>
 
 /** @brief Read a range of logical blocks.
 

--- a/obc/app/reliance_edge/core/driver/buffer.c
+++ b/obc/app/reliance_edge/core/driver/buffer.c
@@ -33,8 +33,9 @@
     through this module.  When a buffer is needed for a block which is not in
     the cache, a "victim" is selected via a simple LRU scheme.
 */
-#include <redfs.h>
 #include <redcore.h>
+#include <redfs.h>
+
 #include "redbufferpriv.h"
 
 #if BUFFER_MODULE == BM_SIMPLE

--- a/obc/app/reliance_edge/core/driver/buffercmn.c
+++ b/obc/app/reliance_edge/core/driver/buffercmn.c
@@ -26,8 +26,9 @@
 /** @file
     @brief Common (shared) buffer module functions.
 */
-#include <redfs.h>
 #include <redcore.h>
+#include <redfs.h>
+
 #include "redbufferpriv.h"
 
 #ifdef REDCONF_ENDIAN_SWAP

--- a/obc/app/reliance_edge/core/driver/core.c
+++ b/obc/app/reliance_edge/core/driver/core.c
@@ -26,10 +26,10 @@
 /** @file
     @brief Implements the entry-points to the core file system.
 */
-#include <redfs.h>
-#include <redcoreapi.h>
-#include <redcore.h>
 #include <redbdev.h>
+#include <redcore.h>
+#include <redcoreapi.h>
+#include <redfs.h>
 
 #if (REDCONF_READ_ONLY == 0) && (REDCONF_API_POSIX == 1)
 static REDSTATUS CoreCreate(uint32_t ulPInode, const char *pszName, uint16_t uMode, uint32_t *pulInode);

--- a/obc/app/reliance_edge/core/driver/format.c
+++ b/obc/app/reliance_edge/core/driver/format.c
@@ -26,10 +26,10 @@
 /** @file
     @brief Implements the Reliance Edge file system formatter.
 */
-#include <redfs.h>
-#include <redcoreapi.h>
-#include <redcore.h>
 #include <redbdev.h>
+#include <redcore.h>
+#include <redcoreapi.h>
+#include <redfs.h>
 
 #if FORMAT_SUPPORTED
 

--- a/obc/app/reliance_edge/core/driver/imap.c
+++ b/obc/app/reliance_edge/core/driver/imap.c
@@ -30,8 +30,8 @@
     tracks which blocks are allocated or free.  Some of the functionality is
     delegated to imapinline.c and imapextern.c.
 */
-#include <redfs.h>
 #include <redcore.h>
+#include <redfs.h>
 
 /** @brief Get the allocation bit of a block from either metaroot.
 

--- a/obc/app/reliance_edge/core/driver/inode.c
+++ b/obc/app/reliance_edge/core/driver/inode.c
@@ -26,8 +26,8 @@
 /** @file
     @brief Implements inode functions.
 */
-#include <redfs.h>
 #include <redcore.h>
+#include <redfs.h>
 
 #if DELETE_SUPPORTED
 static REDSTATUS InodeDelete(CINODE *pInode);

--- a/obc/app/reliance_edge/core/driver/inodedata.c
+++ b/obc/app/reliance_edge/core/driver/inodedata.c
@@ -26,8 +26,8 @@
 /** @file
     @brief Implements inode I/O functions.
 */
-#include <redfs.h>
 #include <redcore.h>
+#include <redfs.h>
 
 /*  Get the buffer flag for an inode's data block.
  */

--- a/obc/app/reliance_edge/core/driver/volume.c
+++ b/obc/app/reliance_edge/core/driver/volume.c
@@ -26,9 +26,9 @@
 /** @file
     @brief Implements core volume operations.
 */
-#include <redfs.h>
-#include <redcore.h>
 #include <redbdev.h>
+#include <redcore.h>
+#include <redfs.h>
 
 /*  Minimum number of blocks needed for metadata on any volume: the master
     block (1), the two metaroots (2), and one doubly-allocated inode (2),

--- a/obc/app/reliance_edge/core/include/redcore.h
+++ b/obc/app/reliance_edge/core/include/redcore.h
@@ -28,12 +28,13 @@
 #ifndef REDCORE_H
 #define REDCORE_H
 
-#include <redstat.h>
 #include <redformat.h>
+#include <redstat.h>
 #include <redvolume.h>
-#include "rednodes.h"
+
 #include "redcoremacs.h"
 #include "redcorevol.h"
+#include "rednodes.h"
 
 #define META_SIG_MASTER (0x5453414DU)    /* 'MAST' */
 #define META_SIG_METAROOT (0x4154454DU)  /* 'META' */

--- a/obc/app/reliance_edge/fse/fse.c
+++ b/obc/app/reliance_edge/fse/fse.c
@@ -34,9 +34,9 @@
     @{
 */
 
-#include <redvolume.h>
 #include <redcoreapi.h>
 #include <redfse.h>
+#include <redvolume.h>
 
 static REDSTATUS FseEnter(uint8_t bVolNum);
 static void FseLeave(void);

--- a/obc/app/reliance_edge/include/redcoreapi.h
+++ b/obc/app/reliance_edge/include/redcoreapi.h
@@ -32,8 +32,8 @@
 #include <stdio.h>
 #endif
 
-#include <redstat.h>
 #include <redformat.h>
+#include <redstat.h>
 
 REDSTATUS RedCoreInit(void);
 REDSTATUS RedCoreUninit(void);

--- a/obc/app/reliance_edge/include/redfs.h
+++ b/obc/app/reliance_edge/include/redfs.h
@@ -30,15 +30,16 @@
 
 #include <redconf.h>
 #include <redosconf.h>
-#include "redexclude.h"
-#include "redver.h"
-#include "redconfigchk.h"
 #include <redtypes.h>
-#include "rederrno.h"
-#include "redmacs.h"
+
 #include "redapimacs.h"
+#include "redconfigchk.h"
+#include "rederrno.h"
+#include "redexclude.h"
+#include "redmacs.h"
 #include "redmisc.h"
-#include "redutils.h"
 #include "redosserv.h"
+#include "redutils.h"
+#include "redver.h"
 
 #endif

--- a/obc/app/reliance_edge/include/redfse.h
+++ b/obc/app/reliance_edge/include/redfse.h
@@ -51,6 +51,7 @@ extern "C" {
 #if REDCONF_API_FSE == 1
 
 #include <redtypes.h>
+
 #include "redapimacs.h"
 #include "rederrno.h"
 

--- a/obc/app/reliance_edge/include/redposix.h
+++ b/obc/app/reliance_edge/include/redposix.h
@@ -49,10 +49,11 @@ extern "C" {
 #if REDCONF_API_POSIX == 1
 
 #include <redtypes.h>
+
 #include "redapimacs.h"
 #include "rederrno.h"
-#include "redstat.h"
 #include "redformat.h"
+#include "redstat.h"
 
 /** Open for reading only. */
 #define RED_O_RDONLY 0x00000001U

--- a/obc/app/reliance_edge/include/redtests.h
+++ b/obc/app/reliance_edge/include/redtests.h
@@ -30,9 +30,10 @@
 #define REDTESTS_H
 
 #include <redtypes.h>
+
+#include "redformat.h"
 #include "redtestutils.h"
 #include "redver.h"
-#include "redformat.h"
 
 /*  This macro is only defined by the error injection project.
  */

--- a/obc/app/reliance_edge/include/redvolume.h
+++ b/obc/app/reliance_edge/include/redvolume.h
@@ -28,8 +28,9 @@
 #ifndef REDVOLUME_H
 #define REDVOLUME_H
 
+#include <redosconf.h> /* for REDOSCONF_MUTABLE_VOLCONF */
+
 #include "redexclude.h" /* for DISCARD_SUPPORTED */
-#include <redosconf.h>  /* for REDOSCONF_MUTABLE_VOLCONF */
 
 /** Indicates that the sector size should be queried from the block device.
  */

--- a/obc/app/reliance_edge/os/freertos/services/osbdev.c
+++ b/obc/app/reliance_edge/os/freertos/services/osbdev.c
@@ -27,10 +27,9 @@
     @brief Implements block device I/O.
 */
 #include <FreeRTOS.h>
-
+#include <redbdev.h>
 #include <redfs.h>
 #include <redvolume.h>
-#include <redbdev.h>
 
 /*------------------------------------------------------------------------------
     Porting Note:

--- a/obc/app/reliance_edge/os/freertos/services/osmutex.c
+++ b/obc/app/reliance_edge/os/freertos/services/osmutex.c
@@ -28,7 +28,6 @@
 */
 #include <FreeRTOS.h>
 #include <os_semphr.h>
-
 #include <redfs.h>
 
 #if REDCONF_TASK_COUNT > 1U

--- a/obc/app/reliance_edge/os/freertos/services/ostask.c
+++ b/obc/app/reliance_edge/os/freertos/services/ostask.c
@@ -28,7 +28,6 @@
 */
 #include <FreeRTOS.h>
 #include <os_task.h>
-
 #include <redfs.h>
 
 #if (REDCONF_TASK_COUNT > 1U) && (REDCONF_API_POSIX == 1)

--- a/obc/app/reliance_edge/os/freertos/services/ostimestamp.c
+++ b/obc/app/reliance_edge/os/freertos/services/ostimestamp.c
@@ -31,7 +31,6 @@
 */
 #include <FreeRTOS.h>
 #include <os_task.h>
-
 #include <redfs.h>
 
 /*  configTICK_RATE_HZ is almost always 100, 250, 500, or 1000.  If

--- a/obc/app/reliance_edge/posix/path.c
+++ b/obc/app/reliance_edge/posix/path.c
@@ -31,9 +31,9 @@
 #if REDCONF_API_POSIX == 1
 
 #include <redcoreapi.h>
-#include <redvolume.h>
-#include <redposix.h>
 #include <redpath.h>
+#include <redposix.h>
+#include <redvolume.h>
 
 #if (REDCONF_API_POSIX_SYMLINK == 1) && (REDOSCONF_SYMLINK_FOLLOW == 1)
 

--- a/obc/app/reliance_edge/posix/posix.c
+++ b/obc/app/reliance_edge/posix/posix.c
@@ -34,10 +34,10 @@
     @{
 */
 
-#include <redvolume.h>
 #include <redcoreapi.h>
-#include <redposix.h>
 #include <redpath.h>
+#include <redposix.h>
+#include <redvolume.h>
 
 /*-------------------------------------------------------------------
     File Descriptors

--- a/obc/app/reliance_edge/projects/freertos_rm46/host/redconf.c
+++ b/obc/app/reliance_edge/projects/freertos_rm46/host/redconf.c
@@ -6,8 +6,8 @@
 /** @file
  */
 #include <redconf.h>
-#include <redtypes.h>
 #include <redmacs.h>
+#include <redtypes.h>
 #include <redvolume.h>
 
 const VOLCONF gaRedVolConf[REDCONF_VOLUME_COUNT] = {{512U, 1024U, 0U, false, 100U, 0U, ""}};

--- a/obc/app/reliance_edge/tests/posix/fsstress.c
+++ b/obc/app/reliance_edge/tests/posix/fsstress.c
@@ -35,27 +35,26 @@
     This version of SGI fsstress has been modified to be single-threaded and to
     work with the Reliance Edge POSIX-like API.
 */
-#include <stdio.h>
-#include <stdlib.h>
 #include <limits.h>
-#include <string.h>
-#include <stdarg.h>
-#include <time.h>
-
 #include <redposix.h>
 #include <redtests.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #if FSSTRESS_SUPPORTED
 
-#include "redposixcompat.h"
-
-#include <redosserv.h>
-#include <redmisc.h>
-#include <redutils.h>
-#include <redmacs.h>
-#include <redvolume.h>
 #include <redgetopt.h>
+#include <redmacs.h>
+#include <redmisc.h>
+#include <redosserv.h>
 #include <redtoolcmn.h>
+#include <redutils.h>
+#include <redvolume.h>
+
+#include "redposixcompat.h"
 
 #if REDCONF_CHECKER == 1
 #include <redcoreapi.h>

--- a/obc/app/reliance_edge/tests/util/printf.c
+++ b/obc/app/reliance_edge/tests/util/printf.c
@@ -38,9 +38,9 @@
     Do *not* use these functions from within the file system driver.  They are
     not linked into the driver due to their relatively large size.
 */
+#include <limits.h>
 #include <redfs.h>
 #include <redtestutils.h>
-#include <limits.h>
 #include <stdarg.h>
 
 /** @brief Maximum number of bytes of output supported by RedPrintf().

--- a/obc/app/reliance_edge/tools/config/allsettings.cpp
+++ b/obc/app/reliance_edge/tools/config/allsettings.cpp
@@ -23,9 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include "volumesettings.h"
 #include "allsettings.h"
+
 #include "version.h"
+#include "volumesettings.h"
 
 // Private helpers
 static QString outputLine(const QString &macroName, const QString &value, const QString &comment = QString());

--- a/obc/app/reliance_edge/tools/config/allsettings.h
+++ b/obc/app/reliance_edge/tools/config/allsettings.h
@@ -27,13 +27,13 @@
 #define ALLSETTINGS_H
 
 #include "settings/cbsetting.h"
+#include "settings/checkedsbsetting.h"
 #include "settings/cmbintsetting.h"
 #include "settings/cmbstrsetting.h"
+#include "settings/lesetting.h"
 #include "settings/pathsepsetting.h"
 #include "settings/rbtnsetting.h"
 #include "settings/sbsetting.h"
-#include "settings/lesetting.h"
-#include "settings/checkedsbsetting.h"
 
 ///
 /// \brief  Structure containing public settings pointers for global access.

--- a/obc/app/reliance_edge/tools/config/control/application.cpp
+++ b/obc/app/reliance_edge/tools/config/control/application.cpp
@@ -23,10 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "application.h"
+
 #include <QErrorMessage>
 #include <QRegularExpressionMatch>
-
-#include "application.h"
 
 Application::Application(int &argc, char *argv[])
     : QApplication(argc, argv),

--- a/obc/app/reliance_edge/tools/config/control/application.h
+++ b/obc/app/reliance_edge/tools/config/control/application.h
@@ -30,9 +30,9 @@
 #include <QErrorMessage>
 #include <QMessageBox>
 
-#include "ui/configwindow.h"
-#include "output.h"
 #include "input.h"
+#include "output.h"
+#include "ui/configwindow.h"
 
 ///
 /// \brief  The Application class is a child class of QApplication. It runs the

--- a/obc/app/reliance_edge/tools/config/control/input.cpp
+++ b/obc/app/reliance_edge/tools/config/control/input.cpp
@@ -23,9 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "input.h"
+
 #include <QTextStream>
 
-#include "input.h"
 #include "allsettings.h"
 
 Input::Input(QWidget *parentWin) : fileDialog(NULL), parentWindow(parentWin), messageBox(new QMessageBox(parentWin)) {}

--- a/obc/app/reliance_edge/tools/config/control/input.h
+++ b/obc/app/reliance_edge/tools/config/control/input.h
@@ -26,10 +26,10 @@
 #ifndef INPUT_H
 #define INPUT_H
 
-#include <QWidget>
-#include <QObject>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QObject>
+#include <QWidget>
 
 #include "ui/filedialog.h"
 

--- a/obc/app/reliance_edge/tools/config/control/output.cpp
+++ b/obc/app/reliance_edge/tools/config/control/output.cpp
@@ -23,12 +23,13 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include "ui/errordialog.h"
-#include "debug.h"
 #include "output.h"
+
 #include "allsettings.h"
-#include "volumesettings.h"
+#include "debug.h"
+#include "ui/errordialog.h"
 #include "version.h"
+#include "volumesettings.h"
 
 Output::Output(QWidget *parentWin)
     : parentWindow(parentWin), fileDialog(NULL), errorDialog(new ErrorDialog(parentWindow)), isSaving(false) {

--- a/obc/app/reliance_edge/tools/config/control/output.h
+++ b/obc/app/reliance_edge/tools/config/control/output.h
@@ -26,14 +26,14 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 
-#include <QWidget>
-#include <QObject>
 #include <QList>
+#include <QObject>
 #include <QString>
+#include <QWidget>
 
+#include "settings/settingbase.h"
 #include "ui/errordialog.h"
 #include "ui/filedialog.h"
-#include "settings/settingbase.h"
 
 ///
 /// \brief  The Output class controls the processes of reporting invalid values

--- a/obc/app/reliance_edge/tools/config/settings/boolsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/boolsetting.cpp
@@ -23,11 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
+#include "boolsetting.h"
 
 #include <QString>
-
-#include "boolsetting.h"
+#include <stdexcept>
 
 BoolSetting::BoolSetting(QString macroName, bool defaultValue, std::function<Validity(bool, QString &)> validator,
                          WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/boolsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/boolsetting.h
@@ -28,8 +28,8 @@
 
 #include <QString>
 
-#include "ui/warningbtn.h"
 #include "setting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  Class for settings that may be represented using a Boolean type.

--- a/obc/app/reliance_edge/tools/config/settings/cbsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/cbsetting.cpp
@@ -23,11 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
+#include "cbsetting.h"
 
 #include <QString>
-
-#include "cbsetting.h"
+#include <stdexcept>
 
 CbSetting::CbSetting(QString macroName, bool defaultValue, std::function<Validity(bool, QString &)> validator,
                      QCheckBox *cb, WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/cbsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/cbsetting.h
@@ -26,8 +26,8 @@
 #ifndef CBSETTING_H
 #define CBSETTING_H
 
-#include <QString>
 #include <QCheckBox>
+#include <QString>
 
 #include "boolsetting.h"
 

--- a/obc/app/reliance_edge/tools/config/settings/checkedsbsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/checkedsbsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "checkedsbsetting.h"
+
+#include <stdexcept>
 
 CheckedSbSetting::CheckedSbSetting(QString macroName, unsigned long defaultValue,
                                    std::function<Validity(unsigned long, QString &)> validator, QSpinBox *sb,

--- a/obc/app/reliance_edge/tools/config/settings/checkedsbsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/checkedsbsetting.h
@@ -26,12 +26,12 @@
 #ifndef CHECKEDSPSETTING_H
 #define CHECKEDSPSETTING_H
 
-#include <QString>
-#include <QSpinBox>
 #include <QCheckBox>
+#include <QSpinBox>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "intsetting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  The CheckedSbSetting class manages settings that use a QSpinBox

--- a/obc/app/reliance_edge/tools/config/settings/cmbintsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/cmbintsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "cmbintsetting.h"
+
+#include <stdexcept>
 
 CmbIntSetting::CmbIntSetting(QString macroName, unsigned long defaultValue,
                              std::function<Validity(unsigned long, QString &)> validator, QComboBox *cmb,

--- a/obc/app/reliance_edge/tools/config/settings/cmbintsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/cmbintsetting.h
@@ -26,11 +26,11 @@
 #ifndef CMBINTSETTING_H
 #define CMBINTSETTING_H
 
-#include <QString>
 #include <QComboBox>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "intsetting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  The CmbStrSetting class manages settings that use a QComboBox for

--- a/obc/app/reliance_edge/tools/config/settings/cmbstrsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/cmbstrsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "cmbstrsetting.h"
+
+#include <stdexcept>
 
 CmbStrSetting::CmbStrSetting(QString macroName, QString defaultValue,
                              std::function<Validity(QString, QString &)> validator, QComboBox *cmb, WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/cmbstrsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/cmbstrsetting.h
@@ -26,11 +26,11 @@
 #ifndef CMBSETTING_H
 #define CMBSETTING_H
 
-#include <QString>
 #include <QComboBox>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "strsetting.h"
+#include "ui/warningbtn.h"
 ///
 /// \brief  The CmbStrSetting class manages settings that use a QComboBox for
 ///         user input and hold a string value. This includes settings that

--- a/obc/app/reliance_edge/tools/config/settings/dindirreporter.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/dindirreporter.cpp
@@ -23,9 +23,10 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "dindirreporter.h"
+
 #include "allsettings.h"
 #include "validators.h"
-#include "dindirreporter.h"
 
 DindirReporter::DindirReporter(QLabel *dindirLabel) : label(dindirLabel) {
   // Assert this one, assume the others.

--- a/obc/app/reliance_edge/tools/config/settings/intsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/intsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "intsetting.h"
+
+#include <stdexcept>
 
 IntSetting::IntSetting(QString macroName, unsigned long defaultValue,
                        std::function<Validity(unsigned long, QString &)> validator, WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/intsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/intsetting.h
@@ -28,8 +28,8 @@
 
 #include <QString>
 
-#include "ui/warningbtn.h"
 #include "setting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  Class for settings that may be represented using a Boolean type.

--- a/obc/app/reliance_edge/tools/config/settings/lesetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/lesetting.h
@@ -26,11 +26,11 @@
 #ifndef LESETTING_H
 #define LESETTING_H
 
-#include <QString>
 #include <QLineEdit>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "strsetting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  The LeSetting class manages settings that use a QLineEdit for user

--- a/obc/app/reliance_edge/tools/config/settings/limitreporter.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/limitreporter.cpp
@@ -23,10 +23,11 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "limitreporter.h"
+
 #include "allsettings.h"
 #include "validators.h"
 #include "volumesettings.h"
-#include "limitreporter.h"
 
 LimitReporter::LimitReporter(QLabel *fsizeMaxLabel, QLabel *vsizeMaxLabel)
     : labelMaxFsize(fsizeMaxLabel), labelMaxVsize(vsizeMaxLabel) {

--- a/obc/app/reliance_edge/tools/config/settings/pathsepsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/pathsepsetting.h
@@ -26,12 +26,12 @@
 #ifndef PATHSEPSETTING_H
 #define PATHSEPSETTING_H
 
-#include <QString>
 #include <QComboBox>
 #include <QLineEdit>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "strsetting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  The PathSepSetting class is a special case class that manages the

--- a/obc/app/reliance_edge/tools/config/settings/rbtnsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/rbtnsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "rbtnsetting.h"
+
+#include <stdexcept>
 
 RbtnSetting::RbtnSetting(QString macroName, bool defaultValue, std::function<Validity(bool, QString &)> validator,
                          QRadioButton *rbtn, WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/sbsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/sbsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "sbsetting.h"
+
+#include <stdexcept>
 
 SbSetting::SbSetting(QString macroName, unsigned long defaultValue,
                      std::function<Validity(unsigned long, QString &)> validator, QSpinBox *sb, WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/sbsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/sbsetting.h
@@ -26,11 +26,11 @@
 #ifndef SPSETTING_H
 #define SPSETTING_H
 
-#include <QString>
 #include <QSpinBox>
+#include <QString>
 
-#include "ui/warningbtn.h"
 #include "intsetting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  The SbSetting class manages settings that use a QSpinBox for user

--- a/obc/app/reliance_edge/tools/config/settings/setting.h
+++ b/obc/app/reliance_edge/tools/config/settings/setting.h
@@ -26,17 +26,16 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include <functional>
+#include <QList>
+#include <QString>
 #include <exception>
+#include <functional>
 #include <stdexcept>
 
-#include <QString>
-#include <QList>
-
-#include "ui/warningbtn.h"
 #include "debug.h"
-#include "validity.h"
 #include "settingbase.h"
+#include "ui/warningbtn.h"
+#include "validity.h"
 
 ///
 /// \brief  The Setting class is used to represent settings displayed by the UI.

--- a/obc/app/reliance_edge/tools/config/settings/settingbase.h
+++ b/obc/app/reliance_edge/tools/config/settings/settingbase.h
@@ -28,8 +28,8 @@
 
 #include <QList>
 
-#include "validity.h"
 #include "notifiable.h"
+#include "validity.h"
 
 ///
 /// \brief  The SettingBase class is a base class for Setting<T>, allowing

--- a/obc/app/reliance_edge/tools/config/settings/strsetting.cpp
+++ b/obc/app/reliance_edge/tools/config/settings/strsetting.cpp
@@ -23,9 +23,9 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <stdexcept>
-
 #include "strsetting.h"
+
+#include <stdexcept>
 
 StrSetting::StrSetting(QString macroName, QString defaultValue, std::function<Validity(QString, QString &)> validator,
                        WarningBtn *btnWarn)

--- a/obc/app/reliance_edge/tools/config/settings/strsetting.h
+++ b/obc/app/reliance_edge/tools/config/settings/strsetting.h
@@ -28,8 +28,8 @@
 
 #include <QString>
 
-#include "ui/warningbtn.h"
 #include "setting.h"
+#include "ui/warningbtn.h"
 
 ///
 /// \brief  Class for settings that may be represented using a string type.

--- a/obc/app/reliance_edge/tools/config/ui/configwindow.cpp
+++ b/obc/app/reliance_edge/tools/config/ui/configwindow.cpp
@@ -23,15 +23,16 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <QMessageBox>
-#include <QDesktopWidget>
-
-#include "control/output.h"
-#include "version.h"
-#include "allsettings.h"
-#include "validators.h"
 #include "configwindow.h"
+
+#include <QDesktopWidget>
+#include <QMessageBox>
+
+#include "allsettings.h"
+#include "control/output.h"
 #include "ui_configwindow.h"
+#include "validators.h"
+#include "version.h"
 
 ConfigWindow::ConfigWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::ConfigWindow) {
   ui->setupUi(this);

--- a/obc/app/reliance_edge/tools/config/ui/configwindow.h
+++ b/obc/app/reliance_edge/tools/config/ui/configwindow.h
@@ -26,11 +26,11 @@
 #ifndef CONFIGWINDOW_H
 #define CONFIGWINDOW_H
 
-#include <QMainWindow>
 #include <QList>
+#include <QMainWindow>
 
-#include "settings/limitreporter.h"
 #include "settings/dindirreporter.h"
+#include "settings/limitreporter.h"
 #include "volumesettings.h"
 
 namespace Ui {

--- a/obc/app/reliance_edge/tools/config/ui/errordialog.cpp
+++ b/obc/app/reliance_edge/tools/config/ui/errordialog.cpp
@@ -23,10 +23,11 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
-#include <QListWidget>
-#include <QIcon>
-
 #include "errordialog.h"
+
+#include <QIcon>
+#include <QListWidget>
+
 #include "ui_errordialog.h"
 
 ErrorDialog::ErrorDialog(QWidget *parent) : QDialog(parent, Qt::WindowCloseButtonHint), ui(new Ui::ErrorDialog) {

--- a/obc/app/reliance_edge/tools/config/ui/filedialog.cpp
+++ b/obc/app/reliance_edge/tools/config/ui/filedialog.cpp
@@ -24,6 +24,7 @@
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
 #include "filedialog.h"
+
 #include <debug.h>
 
 QString FileDialog::defaultDir = QDir::homePath();

--- a/obc/app/reliance_edge/tools/config/ui/warningbtn.cpp
+++ b/obc/app/reliance_edge/tools/config/ui/warningbtn.cpp
@@ -23,10 +23,11 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "warningbtn.h"
+
 #include <QToolTip>
 
 #include "configwindow.h"
-#include "warningbtn.h"
 #include "ui_warningbtn.h"
 
 // The icons used. These are set the first time the

--- a/obc/app/reliance_edge/tools/config/ui/warningbtn.h
+++ b/obc/app/reliance_edge/tools/config/ui/warningbtn.h
@@ -26,12 +26,12 @@
 #ifndef WARNINGBTN_H
 #define WARNINGBTN_H
 
-#include <QWidget>
 #include <QIcon>
 #include <QMouseEvent>
+#include <QWidget>
 
-#include "validity.h"
 #include "ui_warningbtn.h"
+#include "validity.h"
 
 namespace Ui {
 class WarningBtn;

--- a/obc/app/reliance_edge/tools/config/validators.cpp
+++ b/obc/app/reliance_edge/tools/config/validators.cpp
@@ -29,11 +29,12 @@
 ///         the settings.
 ///
 
+#include "validators.h"
+
 #include <QList>
 
-#include "volumesettings.h"
 #include "allsettings.h"
-#include "validators.h"
+#include "volumesettings.h"
 
 static bool isPowerOfTwo(unsigned long value);
 

--- a/obc/app/reliance_edge/tools/config/volumesettings.cpp
+++ b/obc/app/reliance_edge/tools/config/volumesettings.cpp
@@ -23,11 +23,12 @@
 
     Visit https://www.tuxera.com/products/reliance-edge/ for more information.
 */
+#include "volumesettings.h"
+
 #include <stdexcept>
 
-#include "validators.h"
 #include "allsettings.h"
-#include "volumesettings.h"
+#include "validators.h"
 
 extern const char *const gpszSupported = "Supported";
 extern const char *const gpszUnsupported = "Unsupported";

--- a/obc/app/reliance_edge/tools/config/volumesettings.h
+++ b/obc/app/reliance_edge/tools/config/volumesettings.h
@@ -26,15 +26,15 @@
 #ifndef VOLUMESETTINGS_H
 #define VOLUMESETTINGS_H
 
-#include <QString>
-#include <QLineEdit>
-#include <QSpinBox>
-#include <QLabel>
-#include <QComboBox>
 #include <QCheckBox>
-#include <QPushButton>
-#include <QListWidget>
+#include <QComboBox>
+#include <QLabel>
+#include <QLineEdit>
 #include <QList>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QString>
 
 #include "settings/cbsetting.h"
 #include "settings/intsetting.h"

--- a/obc/app/reliance_edge/tools/getopt.c
+++ b/obc/app/reliance_edge/tools/getopt.c
@@ -52,14 +52,13 @@
     symbols with external linkage to avoid naming conflicts in systems where
     there are real getopt()/getopt_long() implementations, and for portability.
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include <rederrno.h>
 #include <redfs.h>
 #include <redgetopt.h>
 #include <redtestutils.h>
-#include <rederrno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int32_t red_opterr = 1;   /* if error message should be printed */
 int32_t red_optind = 1;   /* index into parent argv vector */

--- a/obc/app/reliance_edge/tools/imgbld/ibfse.c
+++ b/obc/app/reliance_edge/tools/imgbld/ibfse.c
@@ -31,14 +31,13 @@
 
 #if (REDCONF_IMAGE_BUILDER == 1) && (REDCONF_API_FSE == 1)
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
-
 #include <redfse.h>
-#include <redtools.h>
 #include <redtoolcmn.h>
+#include <redtools.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 typedef struct sSTRLISTENTRY STRLISTENTRY;
 struct sSTRLISTENTRY {

--- a/obc/app/reliance_edge/tools/imgbld/ibposix.c
+++ b/obc/app/reliance_edge/tools/imgbld/ibposix.c
@@ -31,12 +31,11 @@
 
 #if (REDCONF_IMAGE_BUILDER == 1) && (REDCONF_API_POSIX == 1)
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <errno.h>
-
 #include <redposix.h>
 #include <redtools.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 int IbApiInit(void) {
   int ret = 0;

--- a/obc/app/reliance_edge/tools/imgbld/imgbld.c
+++ b/obc/app/reliance_edge/tools/imgbld/imgbld.c
@@ -26,21 +26,20 @@
 /** @file
     @brief Implements a command-line image builder tool.
 */
+#include <errno.h>
+#include <limits.h>
+#include <redfs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
-
-#include <redfs.h>
 
 #if REDCONF_IMAGE_BUILDER == 1
 
-#include <redvolume.h>
+#include <redcoreapi.h>
 #include <redgetopt.h>
 #include <redtoolcmn.h>
-#include <redcoreapi.h>
 #include <redtools.h>
+#include <redvolume.h>
 
 #define COPY_BUFFER_SIZE_MIN (1024U)
 #define COPY_BUFFER_SIZE_MAX (32UL * 1024 * 1024)

--- a/obc/app/reliance_edge/tools/mditer.c
+++ b/obc/app/reliance_edge/tools/mditer.c
@@ -43,15 +43,14 @@
     This utility is used with the endian-swapping tests, and thus it must be
     endian agnostic.
 */
-#include <stdlib.h>
-#include <stdio.h>
-
-#include <redfs.h>
 #include <redbdev.h>
-#include <redvolume.h>
-#include <redcoreapi.h>
 #include <redcore.h>
+#include <redcoreapi.h>
+#include <redfs.h>
 #include <redmditer.h>
+#include <redvolume.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define SWAP16(val) ((((val) & 0xFF00U) >> 8U) | (((val) & 0x00FFU) << 8U))
 #define SWAP32(val)                                                                                 \

--- a/obc/app/reliance_edge/tools/toolcmn.c
+++ b/obc/app/reliance_edge/tools/toolcmn.c
@@ -26,16 +26,15 @@
 /** @file
     @brief Implements common-code utilities for tools and tests.
 */
-#include <stdio.h>
-#include <stdlib.h>
 #include <errno.h>
 #include <limits.h>
-#include <string.h>
-
-#include <redfs.h>
 #include <redcoreapi.h>
-#include <redvolume.h>
+#include <redfs.h>
 #include <redtoolcmn.h>
+#include <redvolume.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define ISDIGIT(c) (((c) >= '0') && ((c) <= '9'))
 

--- a/obc/app/rtos/obc_scheduler_config.c
+++ b/obc/app/rtos/obc_scheduler_config.c
@@ -1,15 +1,14 @@
 // This code is generated, do not modify directly!
 #include "obc_scheduler_config.h"
 
-#include "obc_errors.h"
-#include "obc_assert.h"
-
 #include <FreeRTOS.h>
 #include <FreeRTOSConfig.h>
 #include <os_task.h>
+#include <stdint.h>
 #include <sys_common.h>
 
-#include <stdint.h>
+#include "obc_assert.h"
+#include "obc_errors.h"
 
 /* DEFINES */
 #define OBC_SCHEDULER_MAX_PRIORITY configMAX_PRIORITIES - 1U

--- a/obc/app/sys/fs_wrapper/obc_reliance_fs.c
+++ b/obc/app/sys/fs_wrapper/obc_reliance_fs.c
@@ -1,8 +1,9 @@
 #include "obc_reliance_fs.h"
-#include "obc_logging.h"
-#include "obc_errors.h"
 
 #include <redposix.h>
+
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 obc_error_code_t setupFileSystem(void) {
   int32_t ret;

--- a/obc/app/sys/fs_wrapper/obc_reliance_fs.h
+++ b/obc/app/sys/fs_wrapper/obc_reliance_fs.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#include "obc_errors.h"
 
 /**
  * @brief Setup the file system.

--- a/obc/app/sys/metadata/obc_metadata.c
+++ b/obc/app/sys/metadata/obc_metadata.c
@@ -1,4 +1,5 @@
 #include "obc_metadata.h"
+
 #include "obc_errors.h"
 
 extern void _c_int00(void);

--- a/obc/app/sys/persistent/obc_persistent.c
+++ b/obc/app/sys/persistent/obc_persistent.c
@@ -1,12 +1,12 @@
 #include "obc_persistent.h"
 
+#include <string.h>
+
 #include "fm25v20a.h"
 #include "obc_assert.h"
+#include "obc_crc.h"
 #include "obc_errors.h"
 #include "obc_logging.h"
-#include "obc_crc.h"
-
-#include <string.h>
 
 /* Config */
 static const obc_persist_config_t obcPersistConfig[] = {

--- a/obc/app/sys/persistent/obc_persistent.h
+++ b/obc/app/sys/persistent/obc_persistent.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <stdlib.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include "obc_errors.h"
 

--- a/obc/app/sys/print/obc_print.c
+++ b/obc/app/sys/print/obc_print.c
@@ -1,13 +1,14 @@
-#include "obc_errors.h"
-#include "obc_assert.h"
-#include "obc_board_config.h"
 #include "obc_print.h"
-#include "obc_logging.h"
 
 #include <sci.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#include "obc_assert.h"
+#include "obc_board_config.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 #define OBC_UART_BAUD_RATE 115200
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY

--- a/obc/app/sys/time/obc_time.c
+++ b/obc/app/sys/time/obc_time.c
@@ -1,17 +1,17 @@
 #include "obc_time.h"
-#include "obc_time_utils.h"
-#include "obc_errors.h"
-#include "obc_logging.h"
-#include "obc_assert.h"
-#include "ds3232_mz.h"
 
 #include <FreeRTOS.h>
-#include <os_task.h>
 #include <os_atomic.h>
-
-#include <stdint.h>
+#include <os_task.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
+
+#include "ds3232_mz.h"
+#include "obc_assert.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_time_utils.h"
 
 // Global Unix time
 static volatile uint32_t currTime;

--- a/obc/app/sys/time/obc_time.h
+++ b/obc/app/sys/time/obc_time.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-#include "ds3232_mz.h"
-
 #include <stdint.h>
+
+#include "ds3232_mz.h"
+#include "obc_errors.h"
 
 /**
  * @brief Initialize the time module.

--- a/obc/app/sys/time/obc_time_utils.c
+++ b/obc/app/sys/time/obc_time_utils.c
@@ -1,9 +1,10 @@
 #include "obc_time_utils.h"
-#include "obc_errors.h"
-#include "ds3232_mz.h"
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#include "ds3232_mz.h"
+#include "obc_errors.h"
 
 obc_error_code_t datetimeToUnix(rtc_date_time_t *datetime, uint32_t *unixTime) {
   if (datetime == NULL || unixTime == NULL) {

--- a/obc/app/sys/time/obc_time_utils.h
+++ b/obc/app/sys/time/obc_time_utils.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "obc_errors.h"
-#include "ds3232_mz.h"
-
 #include <stdint.h>
+
+#include "ds3232_mz.h"
+#include "obc_errors.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/obc/app/sys/utils/obc_crc.c
+++ b/obc/app/sys/utils/obc_crc.c
@@ -1,10 +1,9 @@
 #include "obc_crc.h"
 
+#include <redutils.h>
+#include <stdbool.h>  // required by redutils.h
 #include <stdint.h>
 #include <string.h>
-
-#include <stdbool.h>  // required by redutils.h
-#include <redutils.h>
 
 uint32_t computeCrc32(const uint32_t prevCrc32, const uint8_t* buffer, size_t len) {
   return RedCrc32Update(prevCrc32, buffer, len);

--- a/obc/app/sys/utils/obc_crc.h
+++ b/obc/app/sys/utils/obc_crc.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /**
  * @brief Compute the CRC32 of a buffer.

--- a/obc/app/sys/utils/obc_heap.c
+++ b/obc/app/sys/utils/obc_heap.c
@@ -1,8 +1,7 @@
-#include "sys_heap.h"
-#include "obc_privilege.h"
-
 #include "FreeRTOS.h"
+#include "obc_privilege.h"
 #include "os_portable.h"
+#include "sys_heap.h"
 
 /**
  * @brief Allocates a block of size bytes of memory, returning a pointer to the beginning of the block.

--- a/obc/app/tools/interface_debug_tool/source/main.c
+++ b/obc/app/tools/interface_debug_tool/source/main.c
@@ -1,28 +1,25 @@
-#include "obc_board_config.h"
-#include "obc_spi_io.h"
-#include "obc_sci_io.h"
-#include "obc_print.h"
-#include "obc_i2c_io.h"
-#include "obc_logging.h"
-
-#include "op_codes.h"
-
-#include "test_sci.h"
-#include "test_spi.h"
-#include "test_i2c.h"
-#include "test_can.h"
-#include "test_adc.h"
-#include "test_gio.h"
-#include "test_lm75bd.h"
 #include <FreeRTOS.h>
+#include <i2c.h>
 #include <os_task.h>
-
-#include <sys_common.h>
 #include <sci.h>
 #include <spi.h>
-#include <i2c.h>
-
 #include <string.h>
+#include <sys_common.h>
+
+#include "obc_board_config.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
+#include "op_codes.h"
+#include "test_adc.h"
+#include "test_can.h"
+#include "test_gio.h"
+#include "test_i2c.h"
+#include "test_lm75bd.h"
+#include "test_sci.h"
+#include "test_spi.h"
 
 #define TASK_STACK_SIZE 1024
 

--- a/obc/app/tools/interface_debug_tool/source/test_adc.c
+++ b/obc/app/tools/interface_debug_tool/source/test_adc.c
@@ -1,4 +1,5 @@
 #include "test_adc.h"
+
 #include "obc_print.h"
 
 void testADC(void) { sciPrintf("Testing ADC...\r\n"); }

--- a/obc/app/tools/interface_debug_tool/source/test_can.c
+++ b/obc/app/tools/interface_debug_tool/source/test_can.c
@@ -1,4 +1,5 @@
 #include "test_can.h"
+
 #include "obc_print.h"
 
 void testCAN(void) { sciPrintf("Testing CAN...\r\n"); }

--- a/obc/app/tools/interface_debug_tool/source/test_gio.c
+++ b/obc/app/tools/interface_debug_tool/source/test_gio.c
@@ -1,6 +1,7 @@
 #include "test_gio.h"
-#include "obc_print.h"
+
 #include "gio.h"
+#include "obc_print.h"
 
 void testGIO(void) {
   sciPrintf("Testing GIO...\r\n");

--- a/obc/app/tools/interface_debug_tool/source/test_i2c.c
+++ b/obc/app/tools/interface_debug_tool/source/test_i2c.c
@@ -1,6 +1,7 @@
 #include "test_i2c.h"
-#include "obc_print.h"
+
 #include "obc_i2c_io.h"
+#include "obc_print.h"
 
 #define I2C_MUTEX_TIMEOUT portMAX_DELAY
 #define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)

--- a/obc/app/tools/interface_debug_tool/source/test_lm75bd.c
+++ b/obc/app/tools/interface_debug_tool/source/test_lm75bd.c
@@ -1,7 +1,8 @@
 #include "test_lm75bd.h"
+
 #include "lm75bd.h"
-#include "obc_sci_io.h"
 #include "obc_print.h"
+#include "obc_sci_io.h"
 
 #define EXPECTED_TEMP_RANGE1 10.0f
 #define EXPECTED_TEMP_RANGE2 30.0f

--- a/obc/app/tools/interface_debug_tool/source/test_sci.c
+++ b/obc/app/tools/interface_debug_tool/source/test_sci.c
@@ -1,4 +1,5 @@
 #include "test_sci.h"
+
 #include "obc_print.h"
 
 void testSCI(void) { sciPrintf("Testing SCI...\r\n"); }

--- a/obc/app/tools/interface_debug_tool/source/test_spi.c
+++ b/obc/app/tools/interface_debug_tool/source/test_spi.c
@@ -1,4 +1,5 @@
 #include "test_spi.h"
+
 #include "obc_print.h"
 
 void testSPI(void) { sciPrintf("Testing SPI...\r\n"); }

--- a/obc/bl/F021_Flash_API/include/F021.h
+++ b/obc/bl/F021_Flash_API/include/F021.h
@@ -40,12 +40,12 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wno-wchar-size-warning"
 
-#include "Types.h"
-#include "Helpers.h"
-#include "Constants.h"
-#include "Registers.h"
-#include "FapiFunctions.h"
 #include "Compatibility.h"
+#include "Constants.h"
+#include "FapiFunctions.h"
+#include "Helpers.h"
+#include "Registers.h"
+#include "Types.h"
 
 #pragma GCC diagnostic pop
 

--- a/obc/bl/F021_Flash_API/include/Types.h
+++ b/obc/bl/F021_Flash_API/include/Types.h
@@ -30,8 +30,8 @@
  * INCLUDES
  *********************************************************************************************************************/
 /*LDRA_NOANALYSIS*/
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 /*LDRA_ANALYSIS*/
 
 #if defined(__TI_COMPILER_VERSION__) /* TI CCS Compiler */

--- a/obc/bl/bl_main.c
+++ b/obc/bl/bl_main.c
@@ -1,22 +1,23 @@
-#include "bl_uart.h"
-#include "bl_flash.h"
-#include "obc_gs_commands_response.h"
-#include "obc_gs_commands_response_pack.h"
-#include "obc_gs_errors.h"
-#include "obc_gs_crc.h"
-#include "obc_errors.h"
-#include "obc_gs_command_data.h"
-#include "obc_gs_command_unpack.h"
 #include <metadata_struct.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include "command.h"
-#include "obc_logging.h"
+
 #include "bl_config.h"
 #include "bl_errors.h"
+#include "bl_flash.h"
 #include "bl_time.h"
+#include "bl_uart.h"
+#include "command.h"
+#include "obc_errors.h"
+#include "obc_gs_command_data.h"
+#include "obc_gs_command_unpack.h"
+#include "obc_gs_commands_response.h"
+#include "obc_gs_commands_response_pack.h"
+#include "obc_gs_crc.h"
+#include "obc_gs_errors.h"
+#include "obc_logging.h"
 #include "obc_metadata.h"
 #if defined(DEBUG) && !defined(OBC_REVISION_2)
 #include <gio.h>

--- a/obc/bl/include/bl_flash.h
+++ b/obc/bl/include/bl_flash.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "bl_errors.h"
 

--- a/obc/bl/include/bl_time.h
+++ b/obc/bl/include/bl_time.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "rti.h"
 #include <sci.h>
+
+#include "rti.h"
 
 /* Initalizes the timer */
 void blInitTick();

--- a/obc/bl/include/bl_uart.h
+++ b/obc/bl/include/bl_uart.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "obc_board_config.h"
 #include "obc_errors.h"
-#include <stdint.h>
 
 /**
  * @brief Initialize the UART module

--- a/obc/bl/source/bl_command_callbacks.c
+++ b/obc/bl/source/bl_command_callbacks.c
@@ -1,19 +1,20 @@
-#include "reg_system.h"
-#include "bl_errors.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
 #include "bl_config.h"
+#include "bl_errors.h"
+#include "bl_flash.h"
 #include "bl_time.h"
+#include "bl_uart.h"
+#include "command.h"
 #include "obc_errors.h"
 #include "obc_general_util.h"
 #include "obc_gs_command_data.h"
 #include "obc_gs_command_id.h"
-#include "command.h"
-#include <stddef.h>
 #include "obc_gs_crc.h"
-#include <stdint.h>
-#include "bl_uart.h"
-#include "bl_flash.h"
 #include "obc_metadata.h"
-#include <stdio.h>
+#include "reg_system.h"
 
 #define BL_BIN_RX_CHUNK_SIZE 208U  // Bytes
 #define MAX_PACKET_SIZE 223

--- a/obc/bl/source/bl_flash.c
+++ b/obc/bl/source/bl_flash.c
@@ -1,16 +1,16 @@
 #include "bl_flash.h"
-#include "bl_flash_config.h"
-#include "bl_config.h"
-#include "bl_errors.h"
-
-#include "F021.h"
-#include "reg_flash.h"
-#include "sys_core.h"
 
 #include <FapiFunctions.h>
 #include <Types.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+
+#include "F021.h"
+#include "bl_config.h"
+#include "bl_errors.h"
+#include "bl_flash_config.h"
+#include "reg_flash.h"
+#include "sys_core.h"
 
 /* DEFINES */
 #define BL_FLASH_APP_SECTORS_MASK 0xFF00U  // Sectors 0-7 are reserved for the bootloader

--- a/obc/bl/source/bl_time.c
+++ b/obc/bl/source/bl_time.c
@@ -1,4 +1,5 @@
 #include "bl_time.h"
+
 #include <stdint.h>
 
 static uint32_t initTime;

--- a/obc/bl/source/bl_uart.c
+++ b/obc/bl/source/bl_uart.c
@@ -1,11 +1,12 @@
 #include "bl_uart.h"
-#include "bl_time.h"
-#include "obc_errors.h"
-#include "sci.h"
 
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#include "bl_time.h"
+#include "obc_errors.h"
+#include "sci.h"
 
 /* DEFINES */
 #define BL_UART_SCIREG_BAUD 115200U

--- a/obc/examples/dma_spi_demo/main.c
+++ b/obc/examples/dma_spi_demo/main.c
@@ -1,27 +1,26 @@
-#include "obc_logging.h"
-#include "obc_sci_io.h"
-#include "obc_print.h"
-#include "obc_i2c_io.h"
-#include "obc_spi_io.h"
-#include "sys_dma.h"
-#include "mibspi.h"
-#include "obc_spi_dma.h"
-#include "obc_privilege.h"
-
 #include <FreeRTOS.h>
+#include <can.h>
+#include <gio.h>
+#include <het.h>
+#include <i2c.h>
 #include <os_task.h>
-
+#include <sci.h>
+#include <spi.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys_common.h>
 #include <sys_core.h>
-#include <gio.h>
-#include <sci.h>
-#include <i2c.h>
-#include <spi.h>
-#include <can.h>
-#include <het.h>
 #include <system.h>
-#include <stdint.h>
+
+#include "mibspi.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_privilege.h"
+#include "obc_sci_io.h"
+#include "obc_spi_dma.h"
+#include "obc_spi_io.h"
+#include "sys_dma.h"
 
 /* example data Pattern configuration */
 #define D_SIZE 127

--- a/obc/examples/test_app_adc/main.c
+++ b/obc/examples/test_app_adc/main.c
@@ -1,16 +1,15 @@
+#include <FreeRTOS.h>
+#include <adc.h>
+#include <os_task.h>
+#include <sci.h>
+#include <sys_common.h>
+#include <sys_core.h>
+
 #include "obc_adc.h"
-#include "obc_sci_io.h"
 #include "obc_errors.h"
 #include "obc_print.h"
 #include "obc_scheduler_config.h"
-
-#include <FreeRTOS.h>
-#include <os_task.h>
-#include <sci.h>
-#include <adc.h>
-
-#include <sys_common.h>
-#include <sys_core.h>
+#include "obc_sci_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_arducam/main.c
+++ b/obc/examples/test_app_arducam/main.c
@@ -1,20 +1,19 @@
-#include "obc_logging.h"
-#include "obc_errors.h"
-#include "obc_sci_io.h"
-#include "obc_spi_io.h"
-#include "obc_i2c_io.h"
-#include "obc_print.h"
+#include <gio.h>
+#include <i2c.h>
+#include <sci.h>
+#include <spi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "arducam.h"
 #include "camera_control.h"
-
-#include <gio.h>
-#include <sci.h>
-#include <spi.h>
-#include <i2c.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include "obc_errors.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 // BUFFER_SIZE must be a multiple of 3 for base64 conversion

--- a/obc/examples/test_app_cc1120_spi/cc1120_spi_tests.c
+++ b/obc/examples/test_app_cc1120_spi/cc1120_spi_tests.c
@@ -1,8 +1,10 @@
 #include "cc1120_spi_tests.h"
-#include "cc1120_spi.h"
+
+#include <string.h>
+
 #include "cc1120_defs.h"
 #include "cc1120_mcu.h"
-#include <string.h>
+#include "cc1120_spi.h"
 
 uint8_t CC1120_REGS_DEFAULTS[CC1120_REGS_STD_SPACE_SIZE] = {
     CC1120_DEFAULTS_IOCFG3,         CC1120_DEFAULTS_IOCFG2,

--- a/obc/examples/test_app_cc1120_spi/cc1120_spi_tests.h
+++ b/obc/examples/test_app_cc1120_spi/cc1120_spi_tests.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+
 #include "cc1120.h"
 #include "obc_logging.h"
 

--- a/obc/examples/test_app_cc1120_spi/main.c
+++ b/obc/examples/test_app_cc1120_spi/main.c
@@ -1,17 +1,15 @@
-#include "obc_logging.h"
-#include "obc_sci_io.h"
-#include "obc_spi_io.h"
-
-#include "cc1120_spi_tests.h"
-
-#include "FreeRTOS.h"
-#include "os_task.h"
-#include "os_portable.h"
-
-#include <sys_common.h>
 #include <gio.h>
 #include <sci.h>
 #include <spi.h>
+#include <sys_common.h>
+
+#include "FreeRTOS.h"
+#include "cc1120_spi_tests.h"
+#include "obc_logging.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
+#include "os_portable.h"
+#include "os_task.h"
 
 static TaskHandle_t testTaskHandle = NULL;
 static StaticTask_t testTaskBuffer;

--- a/obc/examples/test_app_fram_persist/main.c
+++ b/obc/examples/test_app_fram_persist/main.c
@@ -1,16 +1,15 @@
-#include "obc_sci_io.h"
-#include "obc_print.h"
-#include "obc_spi_io.h"
-#include "obc_errors.h"
-#include "obc_persistent.h"
-#include "fm25v20a.h"
-
 #include <FreeRTOS.h>
 #include <os_task.h>
-
-#include <sys_common.h>
 #include <sci.h>
 #include <spi.h>
+#include <sys_common.h>
+
+#include "fm25v20a.h"
+#include "obc_errors.h"
+#include "obc_persistent.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_fram_spi/main.c
+++ b/obc/examples/test_app_fram_spi/main.c
@@ -1,13 +1,13 @@
-#include "obc_spi_io.h"
-#include "obc_print.h"
-#include "fm25v20a.h"
-
 #include <gio.h>
 #include <sci.h>
 #include <spi.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fm25v20a.h"
+#include "obc_print.h"
+#include "obc_spi_io.h"
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 

--- a/obc/examples/test_app_freertos_posix/main.c
+++ b/obc/examples/test_app_freertos_posix/main.c
@@ -1,8 +1,8 @@
-#include "posix_example.h"
-#include "console.h"
-
 #include <FreeRTOS.h>
 #include <os_task.h>
+
+#include "console.h"
+#include "posix_example.h"
 
 xTaskHandle dummyTaskHandle;
 

--- a/obc/examples/test_app_freertos_posix/source/posix_example.c
+++ b/obc/examples/test_app_freertos_posix/source/posix_example.c
@@ -1,8 +1,9 @@
 #include "posix_example.h"
-#include "console.h"
 
 #include <FreeRTOS.h>
 #include <os_task.h>
+
+#include "console.h"
 
 void vDummyTask(void* pvParameters) {
   while (1) {

--- a/obc/examples/test_app_lm75bd/main.c
+++ b/obc/examples/test_app_lm75bd/main.c
@@ -1,16 +1,15 @@
-#include "obc_sci_io.h"
-#include "obc_i2c_io.h"
-#include "obc_errors.h"
-#include "obc_print.h"
-#include "lm75bd.h"
-
 #include <FreeRTOS.h>
+#include <i2c.h>
 #include <os_task.h>
-
-#include <sys_common.h>
 #include <sci.h>
 #include <spi.h>
-#include <i2c.h>
+#include <sys_common.h>
+
+#include "lm75bd.h"
+#include "obc_errors.h"
+#include "obc_i2c_io.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_metadata/test_app_metadata.c
+++ b/obc/examples/test_app_metadata/test_app_metadata.c
@@ -1,19 +1,18 @@
-#include "obc_logging.h"
-#include "obc_adc.h"
-#include "obc_sci_io.h"
-#include "obc_errors.h"
-#include "obc_print.h"
-#include "obc_scheduler_config.h"
-#include "obc_metadata.h"
-
 #include <FreeRTOS.h>
-#include <os_task.h>
-#include <sci.h>
 #include <adc.h>
 #include <metadata_struct.h>
-
+#include <os_task.h>
+#include <sci.h>
 #include <sys_common.h>
 #include <sys_core.h>
+
+#include "obc_adc.h"
+#include "obc_errors.h"
+#include "obc_logging.h"
+#include "obc_metadata.h"
+#include "obc_print.h"
+#include "obc_scheduler_config.h"
+#include "obc_sci_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_mpu6050/main.c
+++ b/obc/examples/test_app_mpu6050/main.c
@@ -1,14 +1,13 @@
-#include "obc_sci_io.h"
-#include "obc_i2c_io.h"
-#include "mpu6050.h"
-
 #include <FreeRTOS.h>
+#include <i2c.h>
 #include <os_portmacro.h>
 #include <os_task.h>
+#include <sci.h>
 #include <sys_common.h>
 
-#include <sci.h>
-#include <i2c.h>
+#include "mpu6050.h"
+#include "obc_i2c_io.h"
+#include "obc_sci_io.h"
 
 void taskA(void* pvParameters);
 void taskB(void* pvParameters);

--- a/obc/examples/test_app_mpu6050/source/mpu6050.c
+++ b/obc/examples/test_app_mpu6050/source/mpu6050.c
@@ -1,9 +1,10 @@
 #include "mpu6050.h"
-#include "obc_sci_io.h"
-#include "obc_i2c_io.h"
 
 #include <sci.h>
 #include <stdio.h>
+
+#include "obc_i2c_io.h"
+#include "obc_sci_io.h"
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 #define I2C_TRANSFER_TIMEOUT pdMS_TO_TICKS(100)

--- a/obc/examples/test_app_reliance_edge_sd/main.c
+++ b/obc/examples/test_app_reliance_edge_sd/main.c
@@ -1,16 +1,14 @@
-#include "obc_spi_io.h"
-#include "obc_sci_io.h"
-#include "obc_print.h"
-
 #include <FreeRTOS.h>
 #include <os_task.h>
-
-#include <sys_common.h>
+#include <redposix.h>
 #include <sci.h>
 #include <spi.h>
-
-#include <redposix.h>
 #include <string.h>
+#include <sys_common.h>
+
+#include "obc_print.h"
+#include "obc_sci_io.h"
+#include "obc_spi_io.h"
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 

--- a/obc/examples/test_app_rs/main.c
+++ b/obc/examples/test_app_rs/main.c
@@ -1,13 +1,13 @@
-#include "obc_spi_io.h"
-#include "obc_print.h"
-#include "obc_gs_fec.h"
-
 #include <gio.h>
 #include <sci.h>
 #include <spi.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "obc_gs_fec.h"
+#include "obc_print.h"
+#include "obc_spi_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_rtc/main.c
+++ b/obc/examples/test_app_rtc/main.c
@@ -1,15 +1,14 @@
-#include "obc_i2c_io.h"
-#include "obc_sci_io.h"
-#include "obc_logging.h"
-#include "ds3232_mz.h"
-#include "obc_print.h"
-
 #include <FreeRTOS.h>
-#include <os_task.h>
-
-#include <sys_common.h>
-#include <sci.h>
 #include <i2c.h>
+#include <os_task.h>
+#include <sci.h>
+#include <sys_common.h>
+
+#include "ds3232_mz.h"
+#include "obc_i2c_io.h"
+#include "obc_logging.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/test_app_uart_rx/main.c
+++ b/obc/examples/test_app_uart_rx/main.c
@@ -1,14 +1,13 @@
-#include "obc_print.h"
-#include "obc_sci_io.h"
-#include "obc_board_config.h"
-
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_task.h>
-
+#include <sci.h>
 #include <sys_common.h>
 #include <sys_core.h>
-#include <gio.h>
-#include <sci.h>
+
+#include "obc_board_config.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
 
 #define NUM_CHARS_TO_READ 4U
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY

--- a/obc/examples/test_app_uart_tx/main.c
+++ b/obc/examples/test_app_uart_tx/main.c
@@ -1,8 +1,8 @@
-#include "obc_sci_io.h"
-#include "obc_print.h"
-
 #include <gio.h>
 #include <sci.h>
+
+#include "obc_print.h"
+#include "obc_sci_io.h"
 
 #define UART_MUTEX_BLOCK_TIME portMAX_DELAY
 

--- a/obc/examples/test_attitude_determination_and_controls/main.c
+++ b/obc/examples/test_attitude_determination_and_controls/main.c
@@ -1,15 +1,14 @@
+#include <FreeRTOS.h>
+#include <gio.h>
+#include <os_task.h>
+#include <sci.h>
+#include <sys_common.h>
+#include <sys_core.h>
+
 #include "attitude_control.h"
 #include "attitude_determination_and_vehi.h"
 #include "onboard_env_modelling_types.h"
 #include "vn100.h"
-
-#include <FreeRTOS.h>
-#include <os_task.h>
-
-#include <sys_common.h>
-#include <sys_core.h>
-#include <gio.h>
-#include <sci.h>
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/examples/vn100_demo/test_binary_reading/main.c
+++ b/obc/examples/vn100_demo/test_binary_reading/main.c
@@ -1,15 +1,14 @@
-#include "obc_print.h"
-#include "obc_sci_io.h"
-#include "obc_board_config.h"
-#include "vn100.h"
-
 #include <FreeRTOS.h>
+#include <gio.h>
 #include <os_task.h>
-
+#include <sci.h>
 #include <sys_common.h>
 #include <sys_core.h>
-#include <gio.h>
-#include <sci.h>
+
+#include "obc_board_config.h"
+#include "obc_print.h"
+#include "obc_sci_io.h"
+#include "vn100.h"
 
 static StaticTask_t taskBuffer;
 static StackType_t taskStack[1024];

--- a/obc/shared/commands/command.c
+++ b/obc/shared/commands/command.c
@@ -1,4 +1,5 @@
 #include "command.h"
+
 #include "obc_errors.h"
 #include "obc_gs_command_id.h"
 #include "obc_logging.h"

--- a/obc/shared/commands/command.h
+++ b/obc/shared/commands/command.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+
 #include "obc_errors.h"
 #include "obc_gs_command_data.h"
 

--- a/obc/shared/config/obc_board_config.h
+++ b/obc/shared/config/obc_board_config.h
@@ -1,6 +1,6 @@
-#include <spi.h>
-#include <sci.h>
 #include <gio.h>
+#include <sci.h>
+#include <spi.h>
 
 /* Board macros for registers, ports, CS pins, data formats, etc. */
 

--- a/obc/shared/logging/obc_logging.h
+++ b/obc/shared/logging/obc_logging.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <string.h>
+
+#include "obc_errors.h"
 
 #define __FILE_FROM_REPO_ROOT__ \
   (strstr(__FILE__, SOURCE_PATH) ? strstr(__FILE__, SOURCE_PATH) + sizeof(SOURCE_PATH) - 1 : __FILE__)

--- a/test/interfaces/test_command_pack_unpack.cpp
+++ b/test/interfaces/test_command_pack_unpack.cpp
@@ -1,11 +1,11 @@
-#include "obc_gs_command_pack.h"
-#include "obc_gs_command_unpack.h"
-#include "obc_gs_command_data.h"
-#include "obc_gs_command_id.h"
-#include "obc_gs_errors.h"
-
 #include <gtest/gtest.h>
 #include <stdio.h>
+
+#include "obc_gs_command_data.h"
+#include "obc_gs_command_id.h"
+#include "obc_gs_command_pack.h"
+#include "obc_gs_command_unpack.h"
+#include "obc_gs_errors.h"
 
 // CMD_EXEC_OBC_RESET
 TEST(TestCommandPackUnpack, ValidCmdExecObcResetPackUnpack) {

--- a/test/interfaces/test_command_response_pack_unpack.cpp
+++ b/test/interfaces/test_command_response_pack_unpack.cpp
@@ -1,15 +1,16 @@
 
-#include "obc_gs_command_id.h"
-#include "obc_gs_commands_response_pack.h"
-#include "obc_gs_commands_response_unpack.h"
-#include "obc_gs_fec.h"
-#include "obc_gs_commands_response.h"
-#include "data_unpack_utils.h"
-#include "obc_gs_errors.h"
-
-#include <iostream>
 #include <gtest/gtest.h>
 #include <stdbool.h>
+
+#include <iostream>
+
+#include "data_unpack_utils.h"
+#include "obc_gs_command_id.h"
+#include "obc_gs_commands_response.h"
+#include "obc_gs_commands_response_pack.h"
+#include "obc_gs_commands_response_unpack.h"
+#include "obc_gs_errors.h"
+#include "obc_gs_fec.h"
 
 TEST(pack_unpack_command_responses, packResponse) {
   cmd_response_header_t cmdResponse = {.cmdId = CMD_EXEC_OBC_RESET, .errCode = CMD_RESPONSE_SUCCESS, .dataLen = 2};

--- a/test/interfaces/test_encode_decode_pipeline.cpp
+++ b/test/interfaces/test_encode_decode_pipeline.cpp
@@ -1,19 +1,19 @@
-#include "obc_gs_ax25.h"
-#include "obc_gs_fec.h"
-#include "obc_gs_aes128.h"
-#include "obc_gs_errors.h"
-#include "obc_gs_command_pack.h"
-#include "obc_gs_command_unpack.h"
-#include "obc_gs_command_data.h"
-#include "obc_gs_command_id.h"
-
+#include <gtest/gtest.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
-#include <stdio.h>
 #include <cstdint>
 #include <iostream>
+
+#include "obc_gs_aes128.h"
+#include "obc_gs_ax25.h"
+#include "obc_gs_command_data.h"
+#include "obc_gs_command_id.h"
+#include "obc_gs_command_pack.h"
+#include "obc_gs_command_unpack.h"
+#include "obc_gs_errors.h"
+#include "obc_gs_fec.h"
 
 // TEST: A simulated send with the entire pipline (some bits are also flipped before sending to test fec)
 TEST(TestEncodeDecode, sendData) {

--- a/test/interfaces/test_obc_ax25.cpp
+++ b/test/interfaces/test_obc_ax25.cpp
@@ -1,10 +1,9 @@
-#include "obc_gs_ax25.h"
-#include "obc_gs_fec.h"
-#include "obc_gs_errors.h"
-
+#include <gtest/gtest.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include "obc_gs_ax25.h"
+#include "obc_gs_errors.h"
+#include "obc_gs_fec.h"
 
 // NOTE: AKITO is the groundStationCallsign
 // NOTE: ATLAS is the cubeSatCallSign

--- a/test/interfaces/test_obc_fec.cpp
+++ b/test/interfaces/test_obc_fec.cpp
@@ -1,9 +1,8 @@
-#include "obc_gs_fec.h"
-#include "obc_gs_errors.h"
-
+#include <gtest/gtest.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include "obc_gs_errors.h"
+#include "obc_gs_fec.h"
 
 TEST(TestFecEncodeDecode, EncodeDecodeZeroData) {
   packed_rs_packet_t encodedData = {0};

--- a/test/interfaces/test_pack_unpack_utils.cpp
+++ b/test/interfaces/test_pack_unpack_utils.cpp
@@ -1,7 +1,7 @@
-#include "data_unpack_utils.h"
-#include "data_pack_utils.h"
-
 #include <gtest/gtest.h>
+
+#include "data_pack_utils.h"
+#include "data_unpack_utils.h"
 
 TEST(TestPackAndUnpack, ValidUint8PackUnpack) {
   uint8_t val = 0x12;

--- a/test/interfaces/test_telemetry_pack_unpack.cpp
+++ b/test/interfaces/test_telemetry_pack_unpack.cpp
@@ -1,10 +1,10 @@
+#include <gtest/gtest.h>
+
+#include "obc_gs_errors.h"
+#include "obc_gs_telemetry_data.h"
+#include "obc_gs_telemetry_id.h"
 #include "obc_gs_telemetry_pack.h"
 #include "obc_gs_telemetry_unpack.h"
-#include "obc_gs_telemetry_id.h"
-#include "obc_gs_telemetry_data.h"
-#include "obc_gs_errors.h"
-
-#include <gtest/gtest.h>
 
 TEST(TestTelemetryPackUnpack, ValidTelemObcTempPackUnpack) {
   obc_gs_error_code_t err;

--- a/test/mocks/mock_crc.c
+++ b/test/mocks/mock_crc.c
@@ -1,11 +1,10 @@
 // Copied from obc/reliance_edge/util/crc.c with RED function calls removed
-#include "obc_crc.h"
-
-#include "obc_errors.h"
-
-#include <stdint.h>
 #include <redconf.h>
 #include <redmacs.h>
+#include <stdint.h>
+
+#include "obc_crc.h"
+#include "obc_errors.h"
 
 #define SUSPICIOUS_CRC_VALUE (0xBAADC0DEU)
 

--- a/test/mocks/mock_fram.c
+++ b/test/mocks/mock_fram.c
@@ -1,10 +1,9 @@
-#include "fm25v20a.h"
-
-#include "obc_errors.h"
-#include "obc_assert.h"
-
 #include <stdint.h>
 #include <string.h>
+
+#include "fm25v20a.h"
+#include "obc_assert.h"
+#include "obc_errors.h"
 
 #define MOCK_FRAM_MAX_SIZE 1000  // Change as needed
 static uint8_t memory[MOCK_FRAM_MAX_SIZE] = {0};

--- a/test/mocks/mock_logging.c
+++ b/test/mocks/mock_logging.c
@@ -1,9 +1,9 @@
-#include "obc_logging.h"
-#include "obc_errors.h"
-
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#include "obc_errors.h"
+#include "obc_logging.h"
 
 static log_level_t logLevel;
 static log_output_location_t outputLocation;

--- a/test/unit/test_image_processing.cpp
+++ b/test/unit/test_image_processing.cpp
@@ -1,10 +1,9 @@
-#include "image_processing.h"
-
-#include "obc_errors.h"
 #include <gtest/gtest.h>
-
 #include <stdint.h>
 #include <stdlib.h>
+
+#include "image_processing.h"
+#include "obc_errors.h"
 
 TEST(TestObcImageProcessing, findBrightestPixelInPacket) {
   uint8_t data[640 * 480] = {0};

--- a/test/unit/test_obc_persistent.cpp
+++ b/test/unit/test_obc_persistent.cpp
@@ -1,13 +1,12 @@
+#include "fm25v20a.h"
+#include "obc_errors.h"
 #include "obc_persistent.h"
 
-#include "obc_errors.h"
-#include "fm25v20a.h"
-
 // Test subjects, add more as persistent grows
-#include "obc_time_utils.h"
-#include "alarm_handler.h"
-
 #include <gtest/gtest.h>
+
+#include "alarm_handler.h"
+#include "obc_time_utils.h"
 
 TEST(TestOBCPersistent, InvalidArgs) {
   obc_time_persist_data_t timeData = {0};

--- a/test/unit/test_obc_time_utils.cpp
+++ b/test/unit/test_obc_time_utils.cpp
@@ -1,7 +1,7 @@
-#include "obc_time_utils.h"
-#include "obc_errors.h"
-
 #include <gtest/gtest.h>
+
+#include "obc_errors.h"
+#include "obc_time_utils.h"
 
 TEST(TestObcTimeUtils, ValidDatetimeToUnix) {
   rtc_date_time_t datetime = {.date =

--- a/test/unit/test_vn100_unpack.cpp
+++ b/test/unit/test_vn100_unpack.cpp
@@ -1,10 +1,9 @@
-#include "vn100_binary_parsing.h"
-#include "obc_errors.h"
-
+#include <gtest/gtest.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <gtest/gtest.h>
+#include "obc_errors.h"
+#include "vn100_binary_parsing.h"
 
 TEST(TestVn100PackUnpack, ValidVn100PackUnpack) {
   const uint8_t header[] = {0xFA, 0x01, 0x28, 0x05};


### PR DESCRIPTION
# Purpose
Closes #425
Fix clang-format include sorting by updating IncludeCategories SortPriority values to match the firmware style guide.

# New Changes
- `SortIncludes: true` in `.clang-format`
- If you run `pre-commit run --all-files` this will sort the includes at every file.